### PR TITLE
Wrap status bar in absolutely positioned div.

### DIFF
--- a/lib/status-bar-view.coffee
+++ b/lib/status-bar-view.coffee
@@ -4,8 +4,9 @@ module.exports =
 class StatusBarView extends View
   @content: ->
     @div class: 'status-bar tool-panel panel-bottom', =>
-      @div outlet: 'rightPanel', class: 'status-bar-right pull-right'
-      @div outlet: 'leftPanel', class: 'status-bar-left'
+      @div class: 'flexbox-repaint-hack', =>
+        @div outlet: 'rightPanel', class: 'status-bar-right pull-right'
+        @div outlet: 'leftPanel', class: 'status-bar-left'
 
   initialize: ->
     atom.workspaceView.statusBar = this

--- a/stylesheets/status-bar.less
+++ b/stylesheets/status-bar.less
@@ -2,15 +2,24 @@
 @import "octicon-mixins";
 
 .status-bar {
-  padding: @component-padding/2 @component-padding;
   font-size: 11px;
-  line-height: 14px;
+  line-height: @component-line-height;
+  height: @component-line-height;
   position: relative;
   -webkit-user-select: none;
   cursor: default;
   overflow: hidden;
   white-space: nowrap;
   min-width: -webkit-min-content;
+
+  .flexbox-repaint-hack {
+    padding: 0 @component-line-height/2;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 
   // All icons are smaller than normal (normal is 16px)
   .icon:before {


### PR DESCRIPTION
Flexbox elements repaint their entire canvas after each update. This is a hack to fix that. Bug is referenced here
http://code.google.com/p/chromium/issues/detail?id=332180

Below notice how the repaint (green bar) goes from ~6ms to ~1ms

Before Fix: Timeline for pressing a key
![status-bar less - _users_corey_github_status-bar-5](https://f.cloud.github.com/assets/596/1871411/3743a08c-7896-11e3-9358-26bcdfe4c179.jpg)

After Fix: Timeline for pressing a key
![status-bar less - _users_corey_github_status-bar-6](https://f.cloud.github.com/assets/596/1871456/a17a0b1c-7896-11e3-89e5-a8f6469d2c5f.jpg)
