### PR TITLE
Fix vertical position

### DIFF
--- a/stylesheets/status-bar.less
+++ b/stylesheets/status-bar.less
@@ -24,6 +24,8 @@
   // All icons are smaller than normal (normal is 16px)
   .icon:before {
     .icon-size(14px);
+    position: relative;
+    top: 1px;
     margin-right: 0px;
   }
 


### PR DESCRIPTION
So it seems this lowness might be slightly affected by couple things
- `font-size: 11px` is waay lower than 10px or 12px
- odd numbers of line-height are lower than even numbers. no idea why. 
- the status bar is odd numbered number of px tall, but icons are even, so they never look centered

I cannot figure out why this shit is not in the middle. This, IMO, is the least bad way to handle this. Each theme can do their own magic if they want to have a different sized.

Fixes #11
