### PR TITLE
Provide 'status-bar' service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,41 @@ grammar, current branch, ahead/behind commit counts, and line diff count.
 
 ## API
 
-This package adds a `status-bar` element to the atom workspace.
+This package provides a service that you can use in other Atom packages. To use
+it, include `status-bar` in the `consumedServices` section of your `package.json`:
 
-You can access it from your package by doing the following:
+```json
+{
+  "name": "my-package",
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^0.57.0": "consumeStatusBar"
+      }
+    }
+  }
+}
+```
+
+Then, in your package's main module, call methods on the service:
 
 ```coffee
 module.exports =
-  activate: ->
-    atom.packages.once 'activated', ->
-      statusBar = document.querySelector("status-bar")
-      if statusBar?
-        @statusBarTile = statusBar.addLeftTile(item: myElement, priority: 100)
-  
+  activate: -> # ...
+
+  consumeStatusBar: (statusBar) ->
+    @statusBarTile = statusBar.addLeftTile(item: myElement, priority: 100)
+
   deactivate: ->
+    # ...
     @statusBarTile?.destroy()
+    @statusBarTile = null
 ```
 
-It is important to check that the `status-bar` element is present,
-since the status bar package could be disabled or not installed.
+The `status-bar` API has four methods:
 
-The `status-bar` element has four methods:
-
-  * `addLeftTile({ item, priority })` - Add a tile to the left side of the status bar. Lower priority tiles are placed further to the left. 
-  * `addRightTile({ item, priority })` - Add a tile to the right side of the status bar. Lower priority tiles are placed further to the right. 
+  * `addLeftTile({ item, priority })` - Add a tile to the left side of the status bar. Lower priority tiles are placed further to the left.
+  * `addRightTile({ item, priority })` - Add a tile to the right side of the status bar. Lower priority tiles are placed further to the right.
 
 The `item` parameter to these methods can be a DOM element, a [jQuery object](http://jquery.com), or a model object for which a view provider has been
 registered in the [the view registry](https://atom.io/docs/api/latest/ViewRegistry).

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -91,3 +91,9 @@ module.exports =
     @statusBar = null
 
     delete atom.__workspaceView.statusBar if atom.__workspaceView?
+
+  provideStatusBar: ->
+    addLeftTile: @statusBar.addLeftTile.bind(@statusBar)
+    addRightTile: @statusBar.addRightTile.bind(@statusBar)
+    getLeftTiles: @statusBar.getLeftTiles.bind(@statusBar)
+    getRightTiles: @statusBar.getRightTiles.bind(@statusBar)

--- a/package.json
+++ b/package.json
@@ -12,5 +12,13 @@
     "fs-plus": "^2.0.0",
     "grim": "^1.0.0",
     "space-pen": "^5.0.0"
+  },
+  "providedServices": {
+    "status-bar": {
+      "description": "A container for indicators at the bottom of the workspace",
+      "versions": {
+        "0.58.0": "provideStatusBar"
+      }
+    }
   }
 }

--- a/spec/status-bar-spec.coffee
+++ b/spec/status-bar-spec.coffee
@@ -4,14 +4,16 @@ path = require 'path'
 os = require 'os'
 
 describe "Status Bar package", ->
-  [editor, statusBar, buffer, workspaceElement] = []
+  [editor, statusBar, statusBarService, workspaceElement] = []
 
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
     atom.__workspaceView = {}
 
     waitsForPromise ->
-      atom.packages.activatePackage('status-bar')
+      atom.packages.activatePackage('status-bar').then (pack) ->
+        statusBar = workspaceElement.querySelector("status-bar")
+        statusBarService = pack.mainModule.provideStatusBar()
 
   describe "@activate", ->
     it "appends only one status bar", ->
@@ -40,3 +42,21 @@ describe "Status Bar package", ->
       expect(workspaceElement.querySelector('status-bar').parentNode).not.toBeVisible()
       atom.commands.dispatch(workspaceElement, 'status-bar:toggle')
       expect(workspaceElement.querySelector('status-bar').parentNode).toBeVisible()
+
+  describe "the 'status-bar' service", ->
+    it "allows tiles to be added, removed, and retrieved", ->
+      dummyView = document.createElement("div")
+      tile = statusBarService.addLeftTile(item: dummyView)
+      expect(statusBar).toContain(dummyView)
+      expect(statusBarService.getLeftTiles()).toContain(tile)
+      tile.destroy()
+      expect(statusBar).not.toContain(dummyView)
+      expect(statusBarService.getLeftTiles()).not.toContain(tile)
+
+      dummyView = document.createElement("div")
+      tile = statusBarService.addRightTile(item: dummyView)
+      expect(statusBar).toContain(dummyView)
+      expect(statusBarService.getRightTiles()).toContain(tile)
+      tile.destroy()
+      expect(statusBar).not.toContain(dummyView)
+      expect(statusBarService.getRightTiles()).not.toContain(tile)


### PR DESCRIPTION
The package now provides a `status-bar` service using the APIs introduced in https://github.com/atom/atom/pull/5277.