### PR TITLE
Decouple Services API versions from package versions

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -99,4 +99,4 @@ module.exports =
   # versioning that matched package version.
   legacyProvideStatusBar: ->
      Grim.deprecate("Use at least version 1.0.0 of status-bar Service API.")
-     provideStatusBar()
+     @provideStatusBar()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -98,7 +98,5 @@ module.exports =
   # Depreciated method associated with previous Services API
   # versioning that matched package version.
   legacyProvideStatusBar: ->
-    addLeftTile: @statusBar.addLeftTile.bind(@statusBar)
-    addRightTile: @statusBar.addRightTile.bind(@statusBar)
-    getLeftTiles: @statusBar.getLeftTiles.bind(@statusBar)
-    getRightTiles: @statusBar.getRightTiles.bind(@statusBar)
+     Grim.deprecate("Use at least version 1.0.0 of status-bar Service API.")
+     provideStatusBar()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -98,5 +98,5 @@ module.exports =
   # Depreciated method associated with previous Services API
   # versioning that matched package version.
   legacyProvideStatusBar: ->
-     Grim.deprecate("Use at least version 1.0.0 of status-bar Service API.")
+     Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
      @provideStatusBar()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -94,3 +94,11 @@ module.exports =
     addRightTile: @statusBar.addRightTile.bind(@statusBar)
     getLeftTiles: @statusBar.getLeftTiles.bind(@statusBar)
     getRightTiles: @statusBar.getRightTiles.bind(@statusBar)
+
+  # Depreciated method associated with previous Services API
+  # versioning that matched package version.
+  legacyProvideStatusBar: ->
+    addLeftTile: @statusBar.addLeftTile.bind(@statusBar)
+    addRightTile: @statusBar.addRightTile.bind(@statusBar)
+    getLeftTiles: @statusBar.getLeftTiles.bind(@statusBar)
+    getRightTiles: @statusBar.getRightTiles.bind(@statusBar)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "status-bar": {
       "description": "A container for indicators at the bottom of the workspace",
       "versions": {
-        "0.58.0": "provideStatusBar"
+        "0.58.0": "provideStatusBar",
+        "1.0.0": "provideStatusBar"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "status-bar": {
       "description": "A container for indicators at the bottom of the workspace",
       "versions": {
-        "0.58.0": "provideStatusBar",
-        "1.0.0": "provideStatusBar"
+        "1.0.0": "provideStatusBar",
+        "0.58.0": "legacyProvideStatusBar"
       }
     }
   }


### PR DESCRIPTION
This PR changes the `package.json` to instead use `1.0.0` for the Services API version. The previous `0.58.0` now maps to a new (but identical) method `legacyProvideStatusBar` that will be depreciated with atom/grim. 

See tracking issue: https://github.com/atom/atom/issues/5726