### PR TITLE
Fix spec to check against current branch

### DIFF
--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -181,12 +181,13 @@ describe "Built-in Status Bar Tiles", ->
           atom.workspace.open('HEAD')
 
         runs ->
+          currentBranch = atom.project.getRepositories()[0].getShortHead()
           expect(gitView.branchArea).toBeVisible()
-          expect(gitView.branchLabel.textContent).toBe 'master'
+          expect(gitView.branchLabel.textContent).toBe currentBranch
 
           atom.workspace.getActivePane().destroyItems()
           expect(gitView.branchArea).toBeVisible()
-          expect(gitView.branchLabel.textContent).toBe 'master'
+          expect(gitView.branchLabel.textContent).toBe currentBranch
 
         atom.workspace.getActivePane().activateItem(dummyView)
         expect(gitView.branchArea).not.toBeVisible()


### PR DESCRIPTION
This PR changes the spec so that it checks the visibility of the branch name in the status bar against the current branch name rather than always assuming 'master'.

Should fix the failing tests on #54 #57 :sparkle: 



