### PR TITLE
Don't Grim until everything is on 1.0.0

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -98,5 +98,5 @@ module.exports =
   # Depreciated method associated with previous Services API
   # versioning that matched package version.
   legacyProvideStatusBar: ->
-     Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+     # Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
      @provideStatusBar()


### PR DESCRIPTION
Having the deprecation is causing trouble with tests while packages that consume the `status-bar` service api are being upgraded. 

So for now we're going to keep both APIs but not depreciate it with Grim until _after_ all of those consuming packages have been bumped up to use `1.0.0`.