### PR TITLE
Improve status-bar overlapping

### DIFF
--- a/lib/status-bar-view.coffee
+++ b/lib/status-bar-view.coffee
@@ -11,13 +11,13 @@ class StatusBarView extends HTMLElement
     flexboxHackElement.classList.add('flexbox-repaint-hack')
     @appendChild(flexboxHackElement)
 
-    @rightPanel = document.createElement('div')
-    @rightPanel.classList.add('status-bar-right', 'pull-right')
-    flexboxHackElement.appendChild(@rightPanel)
-
     @leftPanel = document.createElement('div')
     @leftPanel.classList.add('status-bar-left')
     flexboxHackElement.appendChild(@leftPanel)
+
+    @rightPanel = document.createElement('div')
+    @rightPanel.classList.add('status-bar-right', 'pull-right')
+    flexboxHackElement.appendChild(@rightPanel)
 
     @leftTiles = []
     @rightTiles = []

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -20,6 +20,33 @@ status-bar {
     right: 0;
     bottom: 0;
     left: 0;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  // Use 1/3 of space -> will get cut-off first when narrow
+  .status-bar-left {
+    flex: 1 1 33%;
+    overflow-x: auto;
+  }
+
+  // Use 2/3 of space
+  .status-bar-right {
+    padding-left: @component-padding;
+    overflow-x: auto;
+  }
+
+  // Limit inline-blocks from getting too long
+  .inline-block {
+    max-width: 20vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // No width limit for file-info -> will get cut off if too long
+  .inline-block.file-info {
+    max-width: none;
   }
 
   // All icons are smaller than normal (normal is 16px)


### PR DESCRIPTION
#### Problem: 

The left and right sides of the status-bar can overlap when the window gets narrow.

![screen shot 2015-03-07 at 12 07 53 am](https://cloud.githubusercontent.com/assets/378023/6527429/089ebcfc-c45e-11e4-8397-cbac2ebd76e6.png)

#### This PR:
- adds a `max-width` to any `.inline-block`s. Like when there is a huge branch name.
  
![screen shot 2015-03-07 at 12 09 41 am](https://cloud.githubusercontent.com/assets/378023/6527473/5626a89a-c45e-11e4-8d8c-2fe325fe35ca.png)

- prioritizes right side with `2/3` of the space
- left side with `1/3` -> will get cut-off first
- adds overflow scrolling

![status-bar](https://cloud.githubusercontent.com/assets/378023/6527489/75703a0e-c45e-11e4-91bd-6acd5ef8c595.gif)

Fixes #48, #38 and maybe also #53.

#### Questions:

1. There was a flexbox hack added: https://github.com/atom/status-bar/commit/b953bc3a7c89e318545ee89ee8ffa5a5b71b4ddb Not sure if adding a flexbox inside has a negative effect
2. The `.cursor-position` ( e.g. `9/25` after the file path) gets cut off first, maybe it could be moved to the far left, before the file path?