### PR TITLE
Add back the legacy Service API deprecation

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -98,5 +98,5 @@ module.exports =
   # Depreciated method associated with previous Services API
   # versioning that matched package version.
   legacyProvideStatusBar: ->
-     # Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+     Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
      @provideStatusBar()


### PR DESCRIPTION
:warning: **Merge after Atom 0.188.0** :warning: 

This adds back the deprecated Services API call in `status-bar` which had been removed earlier for the sake of :green_apple: tests.

Tracking: https://github.com/atom/atom/issues/5726

