### PR TITLE
Update docs to use status-bar provided service at v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ it, include `status-bar` in the `consumedServices` section of your `package.json
   "consumedServices": {
     "status-bar": {
       "versions": {
-        "^0.57.0": "consumeStatusBar"
+        "^0.58.0": "consumeStatusBar"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ it, include `status-bar` in the `consumedServices` section of your `package.json
   "consumedServices": {
     "status-bar": {
       "versions": {
-        "^0.58.0": "consumeStatusBar"
+        "^1.0.0": "consumeStatusBar"
       }
     }
   }


### PR DESCRIPTION
Docs update. The providedServices are available since v0.58.0 (see https://github.com/atom/status-bar/blob/master/package.json#L21).