### PR TITLE
Update deprecation in legacyProvideStatusBar

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -109,9 +109,9 @@ module.exports =
     addRightTile: (args...) ->
       Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
       sb.addRightTile(args...)
-    getLeftTiles: () ->
+    getLeftTiles: ->
       Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
       sb.getLeftTiles()
-    getRightTiles: () ->
+    getRightTiles: ->
       Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
       sb.getRightTiles()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -104,14 +104,14 @@ module.exports =
     sb = @provideStatusBar()
 
     addLeftTile: (args...) ->
-      Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+      Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
       sb.addLeftTile(args...)
     addRightTile: (args...) ->
-      Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+      Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
       sb.addRightTile(args...)
     getLeftTiles: () ->
-      Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+      Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
       sb.getLeftTiles()
     getRightTiles: () ->
-      Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+      Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
       sb.getRightTiles()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -101,17 +101,17 @@ module.exports =
   # Services API method which would be registered and trigger
   # a deprecation call
   legacyProvideStatusBar: ->
-    sb = @provideStatusBar()
+    statusbar = @provideStatusBar()
 
     addLeftTile: (args...) ->
       Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
-      sb.addLeftTile(args...)
+      statusbar.addLeftTile(args...)
     addRightTile: (args...) ->
       Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
-      sb.addRightTile(args...)
+      statusbar.addRightTile(args...)
     getLeftTiles: ->
       Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
-      sb.getLeftTiles()
+      statusbar.getLeftTiles()
     getRightTiles: ->
       Grim.deprecate("Use version ^1.0.0 of the status-bar Service API.")
-      sb.getRightTiles()
+      statusbar.getRightTiles()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -95,8 +95,23 @@ module.exports =
     getLeftTiles: @statusBar.getLeftTiles.bind(@statusBar)
     getRightTiles: @statusBar.getRightTiles.bind(@statusBar)
 
-  # Depreciated method associated with previous Services API
-  # versioning that matched package version.
+  # Depreciated
+  #
+  # Wrap deprecation calls on the methods returned rather than
+  # Services API method which would be registered and trigger
+  # a deprecation call
   legacyProvideStatusBar: ->
-     Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
-     @provideStatusBar()
+    sb = @provideStatusBar()
+
+    addLeftTile: (args...) ->
+      Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+      sb.addLeftTile(args...)
+    addRightTile: (args...) ->
+      Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+      sb.addRightTile(args...)
+    getLeftTiles: () ->
+      Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+      sb.getLeftTiles()
+    getRightTiles: () ->
+      Grim.deprecate("Use versions ^1.0.0 of status-bar Service API.")
+      sb.getRightTiles()


### PR DESCRIPTION
When the deprecation call was on `legacyProvideStatusBar` it was getting called when the services were registered and causing tests to fail :cry: 

This PR updates `legacyProvideStatusBar` to wrap `provideStatusBar` and have the deprecation call on each method within the object it returns. 