### PR TITLE
remove pull-right class

### DIFF
--- a/lib/status-bar-view.coffee
+++ b/lib/status-bar-view.coffee
@@ -15,7 +15,7 @@ class StatusBarView extends HTMLElement
     flexboxHackElement.appendChild(@leftPanel)
 
     @rightPanel = document.createElement('div')
-    @rightPanel.classList.add('status-bar-right', 'pull-right')
+    @rightPanel.classList.add('status-bar-right')
     flexboxHackElement.appendChild(@rightPanel)
 
     @leftTiles = []

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -34,6 +34,10 @@ status-bar {
   .status-bar-right {
     padding-left: @component-padding;
     overflow-x: auto;
+    .inline-block {
+      margin-right: 0;
+      margin-left: @component-padding;
+    }
   }
 
   // Limit inline-blocks from getting too long


### PR DESCRIPTION
Fix #72 

Floating flexbox children doesn't accomplish anything, so this change doesn't change anything. The right part of the status bar is already aligned properly without the `pull-right` class.
This just cleans up the HTML and CSS.