### PR TITLE
Use a bullet as the line / column separator

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -22,7 +22,7 @@ class CursorPositionView extends HTMLElement
 
   updatePosition: ->
     if position = @getActiveTextEditor()?.getCursorBufferPosition()
-      @textContent = "#{position.row + 1} • #{position.column + 1}"
+      @textContent = "#{position.row + 1}:#{position.column + 1}"
     else
       @textContent = ''
 

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -22,7 +22,7 @@ class CursorPositionView extends HTMLElement
 
   updatePosition: ->
     if position = @getActiveTextEditor()?.getCursorBufferPosition()
-      @textContent = "#{position.row + 1},#{position.column + 1}"
+      @textContent = "#{position.row + 1} • #{position.column + 1}"
     else
       @textContent = ''
 

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -37,7 +37,7 @@ describe "Built-in Status Bar Tiles", ->
 
         runs ->
           expect(fileInfo.currentPath.textContent).toBe 'untitled'
-          expect(cursorPosition.textContent).toBe '1,1'
+          expect(cursorPosition.textContent).toBe '1 • 1'
           expect(selectionCount).toBeHidden()
 
     describe "when the associated editor's path changes", ->
@@ -120,7 +120,7 @@ describe "Built-in Status Bar Tiles", ->
       it "updates the cursor position in the status bar", ->
         jasmine.attachToDOM(workspaceElement)
         editor.setCursorScreenPosition([1, 2])
-        expect(cursorPosition.textContent).toBe '2,3'
+        expect(cursorPosition.textContent).toBe '2 • 3'
 
     describe "when the associated editor's selection changes", ->
       it "updates the selection count in the status bar", ->

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -37,7 +37,7 @@ describe "Built-in Status Bar Tiles", ->
 
         runs ->
           expect(fileInfo.currentPath.textContent).toBe 'untitled'
-          expect(cursorPosition.textContent).toBe '1 • 1'
+          expect(cursorPosition.textContent).toBe '1:1'
           expect(selectionCount).toBeHidden()
 
     describe "when the associated editor's path changes", ->
@@ -120,7 +120,7 @@ describe "Built-in Status Bar Tiles", ->
       it "updates the cursor position in the status bar", ->
         jasmine.attachToDOM(workspaceElement)
         editor.setCursorScreenPosition([1, 2])
-        expect(cursorPosition.textContent).toBe '2 • 3'
+        expect(cursorPosition.textContent).toBe '2:3'
 
     describe "when the associated editor's selection changes", ->
       it "updates the selection count in the status bar", ->


### PR DESCRIPTION
Use a bullet as the line / column separator rather than a comma. The comma separated numbers - with no space after the comma - looked a bit squashed.

Before:

![screen shot 2015-05-23 at 4 48 40 pm](https://cloud.githubusercontent.com/assets/1269969/7786135/d821d46e-016c-11e5-8fe1-007a52586ac1.png)

After:

![screen shot 2015-05-23 at 4 46 26 pm](https://cloud.githubusercontent.com/assets/1269969/7786136/ddba05f4-016c-11e5-9403-afd921ad5306.png)
