### PR TITLE
Add tooltip to cursor position status

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -7,7 +7,8 @@ class CursorPositionView extends HTMLElement
 
     @subscribeToActiveTextEditor()
 
-    @tooltip = atom.tooltips.add(this, title: "Line x, Column y")
+    @tooltip = atom.tooltips.add(this, title: ->
+      "Line #{@row}, Column #{@column}")
 
   destroy: ->
     @activeItemSubscription.dispose()
@@ -25,13 +26,10 @@ class CursorPositionView extends HTMLElement
 
   updatePosition: ->
     if position = @getActiveTextEditor()?.getCursorBufferPosition()
-      row = position.row + 1
-      column = position.column + 1
-      @textContent = "#{row}:#{column}"
-      @tooltip?.dispose()
-      @tooltip = atom.tooltips.add(this, title: "Line #{row}, Column #{column}")
+      @row = position.row + 1
+      @column = position.column + 1
+      @textContent = "#{@row}:#{@column}"
     else
       @textContent = ''
-      @tooltip?.dispose()
 
 module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -7,9 +7,12 @@ class CursorPositionView extends HTMLElement
 
     @subscribeToActiveTextEditor()
 
+    @tooltip = atom.tooltips.add(this, title: "Line x, Column y")
+
   destroy: ->
     @activeItemSubscription.dispose()
     @cursorSubscription?.dispose()
+    @tooltip.dispose()
 
   subscribeToActiveTextEditor: ->
     @cursorSubscription?.dispose()
@@ -22,8 +25,13 @@ class CursorPositionView extends HTMLElement
 
   updatePosition: ->
     if position = @getActiveTextEditor()?.getCursorBufferPosition()
-      @textContent = "#{position.row + 1}:#{position.column + 1}"
+      row = position.row + 1
+      column = position.column + 1
+      @textContent = "#{row}:#{column}"
+      @tooltip?.dispose()
+      @tooltip = atom.tooltips.add(this, title: "Line #{row}, Column #{column}")
     else
       @textContent = ''
+      @tooltip?.dispose()
 
 module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')


### PR DESCRIPTION
From https://github.com/atom/status-bar/pull/76#issuecomment-105055646

This adds a tooltip on hover to the cursor position status tile in the status bar:

![screenshot 2015-05-25 08 24 58](https://cloud.githubusercontent.com/assets/823545/7797262/8c5ae04c-02b7-11e5-81d7-0192a5a20d7f.png)

/cc @atom/feedback 