### PR TITLE
Go to line from cursor position tile

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -1,6 +1,12 @@
+{Disposable} = require 'atom'
+
 class CursorPositionView extends HTMLElement
   initialize: ->
     @classList.add('cursor-position', 'inline-block')
+    @goToLineLink = document.createElement('a')
+    @goToLineLink.classList.add('inline-block')
+    @goToLineLink.href = '#'
+    @appendChild(@goToLineLink)
 
     @formatString = atom.config.get('status-bar.cursorPositionFormat') ? '%L:%C'
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) =>
@@ -12,11 +18,14 @@ class CursorPositionView extends HTMLElement
     @tooltip = atom.tooltips.add(this, title: ->
       "Line #{@row}, Column #{@column}")
 
+    @handleClick()
+
   destroy: ->
     @activeItemSubscription.dispose()
     @cursorSubscription?.dispose()
     @tooltip.dispose()
     @configSubscription?.dispose()
+    @clickSubscription.dispose()
 
   subscribeToActiveTextEditor: ->
     @cursorSubscription?.dispose()
@@ -30,6 +39,11 @@ class CursorPositionView extends HTMLElement
       @formatString = value ? '%L:%C'
       @updatePosition()
 
+  handleClick: ->
+    clickHandler = => atom.commands.dispatch(atom.views.getView(@getActiveTextEditor()), 'go-to-line:toggle')
+    @addEventListener('click', clickHandler)
+    @clickSubscription = new Disposable => @removeEventListener('click', clickHandler)
+
   getActiveTextEditor: ->
     atom.workspace.getActiveTextEditor()
 
@@ -37,8 +51,8 @@ class CursorPositionView extends HTMLElement
     if position = @getActiveTextEditor()?.getCursorBufferPosition()
       @row = position.row + 1
       @column = position.column + 1
-      @textContent = @formatString.replace('%L', @row).replace('%C', @column)
+      @goToLineLink.textContent = @formatString.replace('%L', @row).replace('%C', @column)
     else
-      @textContent = ''
+      @goToLineLink.textContent = ''
 
 module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -52,7 +52,9 @@ class CursorPositionView extends HTMLElement
       @row = position.row + 1
       @column = position.column + 1
       @goToLineLink.textContent = @formatString.replace('%L', @row).replace('%C', @column)
+      @classList.remove('hide')
     else
       @goToLineLink.textContent = ''
+      @classList.add('hide')
 
 module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -2,6 +2,7 @@ Grim = require 'grim'
 fs = require 'fs-plus'
 path = require 'path'
 os = require 'os'
+{$} = require 'atom-space-pen-views'
 
 describe "Built-in Status Bar Tiles", ->
   [statusBar, workspaceElement, dummyView] = []
@@ -241,6 +242,13 @@ describe "Built-in Status Bar Tiles", ->
 
         atom.config.set('status-bar.cursorPositionFormat', 'baz %C quux %L')
         expect(cursorPosition.textContent).toBe 'baz 3 quux 2'
+
+      describe "when clicked", ->
+        it "triggers the go-to-line toggle event", ->
+          eventHandler = jasmine.createSpy('eventHandler')
+          atom.commands.add('atom-text-editor', 'go-to-line:toggle', eventHandler)
+          cursorPosition.click()
+          expect(eventHandler).toHaveBeenCalled()
 
   describe "the git tile", ->
     gitView = null

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -94,4 +94,9 @@ status-bar {
   .git-view {
     display: inline-block;
   }
+
+  .cursor-position a,
+  .cursor-position a:hover {
+    color: @text-color;
+  }
 }

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -85,6 +85,7 @@ status-bar {
     margin-right: -1px;
   }
 
+  .hide,
   .current-path:empty,
   .cursor-position:empty,
   .selection-count:empty {


### PR DESCRIPTION
This is an enhancement inspired by something from VS Code – rather than just being a static tile, this PR changes the cursor position tile to be interactive, opening up `go-to-line:toggle` on click, which I've found to be quite intuitive.

@atom/feedback Can you try this out and see how you like it?

(I'll add a spec in the morning.)