### PR TITLE
More options for cursor position view

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ grammar, current branch, ahead/behind commit counts, and line diff count.
 
 The status-bar package accepts the following configuration values:
 
-* `status-bar.cursorPositionFormat` &mdash; A string that describes the format to use for the cursor position status bar tile. It defaults to `%L:%C`. In the format string, `%L` represents the 1-based line number and `%C` represents the 1-based column number.
+* `status-bar.cursorPositionFormat` and `status-bar.cursorPositionTooltipFormat` &mdash; These strings describe the format to use for the cursor position status bar tile and tooltip. The format strings accept the following interpolations
+    * `%L` is replaced by the 1-based line number.
+    * `%C` is replaced by the 1-based column number.
+    * `%l` is replaced by the number of lines in the file.
+    * `%z` is replaced by the size (number of characters) of the file.
+    * `%o` is replaced by the character offset of the cursor.
+    * `%p` is replaced by the offset divided the size as a percent.
 
 ## API
 

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -37,18 +37,19 @@ class CursorPositionView extends HTMLElement
     if editor = @getActiveTextEditor()
       screenpos = editor.getCursorScreenPosition()
       bufpos = editor.getCursorBufferPosition()
-      buffer = editor.getBuffer()
       @row = bufpos.row + 1
       @column = screenpos.column + 1
       @lineCount = editor.getLineCount()
-      @percent = Math.round(100 * @row / @lineCount)
-      @length = buffer.getText().length # BUG: doesn't update on backspace
+      @length = editor.getText().length
+      @offset = editor.getTextInBufferRange([[0,1], bufpos]).length
+      @percent = Math.round(100 * @offset / @length)
       @textContent = @formatString
         .replace('%L', @row)
         .replace('%C', @column)
         .replace('%l', @lineCount)
-        .replace('%p', @percent)
         .replace('%z', @length)
+        .replace('%o', @offset)
+        .replace('%p', @percent)
     else
       @textContent = ''
 

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -33,13 +33,26 @@ class CursorPositionView extends HTMLElement
   getActiveTextEditor: ->
     atom.workspace.getActiveTextEditor()
 
-  updatePosition: ->
+  getStats: ->
     if editor = @getActiveTextEditor()
       screenpos = editor.getCursorScreenPosition()
       bufpos = editor.getCursorBufferPosition()
-      @row = bufpos.row + 1
-      @column = screenpos.column + 1
-      @textContent = @formatString.replace('%L', @row).replace('%C', @column)
+      buffer = editor.getBuffer()
+      stats =
+        line: bufpos.row + 1
+        column: screenpos.column + 1
+        lineCount: editor.getLineCount()
+        percent: 100 * (bufpos.row + 1) / editor.getLineCount()
+
+  updatePosition: ->
+    if stats = @getStats()
+      @row = stats.line
+      @column = stats.column
+      @textContent = @formatString
+        .replace('%L', stats.line)
+        .replace('%C', stats.column)
+        .replace('%l', stats.lineCount)
+        .replace('%p', Math.round(stats.percent))
     else
       @textContent = ''
 

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -2,15 +2,16 @@ class CursorPositionView extends HTMLElement
   initialize: ->
     @classList.add('cursor-position', 'inline-block')
 
-    @formatString = atom.config.get('status-bar.cursorPositionFormat') ? '%L:%C'
+    @statusFormat = atom.config.get('status-bar.cursorPositionFormat')
+    @tooltipFormat = atom.config.get('status-bar.cursorPositionTooltipFormat')
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) =>
       @subscribeToActiveTextEditor()
 
     @subscribeToConfig()
     @subscribeToActiveTextEditor()
 
-    @tooltip = atom.tooltips.add(this, title: ->
-      "Line #{@row}, Column #{@column}")
+    @tooltip = atom.tooltips.add(this,
+      title: -> @formatString(@tooltipFormat))
 
   destroy: ->
     @activeItemSubscription.dispose()
@@ -27,7 +28,7 @@ class CursorPositionView extends HTMLElement
   subscribeToConfig: ->
     @configSubscription?.dispose()
     @configSubscription = atom.config.observe 'status-bar.cursorPositionFormat', (value) =>
-      @formatString = value ? '%L:%C'
+      @statusFormat = value ? '%L:%C'
       @updatePosition()
 
   getActiveTextEditor: ->
@@ -43,14 +44,17 @@ class CursorPositionView extends HTMLElement
       @length = editor.getText().length
       @offset = editor.getTextInBufferRange([[0,1], bufpos]).length
       @percent = Math.round(100 * @offset / @length)
-      @textContent = @formatString
-        .replace('%L', @row)
-        .replace('%C', @column)
-        .replace('%l', @lineCount)
-        .replace('%z', @length)
-        .replace('%o', @offset)
-        .replace('%p', @percent)
+      @textContent = @formatString(@statusFormat)
     else
       @textContent = ''
+
+  formatString: (str) ->
+    str
+      .replace('%L', @row)
+      .replace('%C', @column)
+      .replace('%l', @lineCount)
+      .replace('%z', @length)
+      .replace('%o', @offset)
+      .replace('%p', @percent)
 
 module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -34,9 +34,11 @@ class CursorPositionView extends HTMLElement
     atom.workspace.getActiveTextEditor()
 
   updatePosition: ->
-    if position = @getActiveTextEditor()?.getCursorBufferPosition()
-      @row = position.row + 1
-      @column = position.column + 1
+    if editor = @getActiveTextEditor()
+      screenpos = editor.getCursorScreenPosition()
+      bufpos = editor.getCursorBufferPosition()
+      @row = bufpos.row + 1
+      @column = screenpos.column + 1
       @textContent = @formatString.replace('%L', @row).replace('%C', @column)
     else
       @textContent = ''

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -43,7 +43,7 @@ class CursorPositionView extends HTMLElement
       @column = screenpos.column + 1
       @lineCount = editor.getLineCount()
       @length = editor.getText().length
-      @offset = editor.getTextInBufferRange([[0,1], bufpos]).length
+      @offset = editor.getTextInBufferRange([[0, 1], bufpos]).length
       @percent = Math.round(100 * @offset / @length)
       @textContent = @formatString(@statusFormat)
     else

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -43,6 +43,7 @@ class CursorPositionView extends HTMLElement
         column: screenpos.column + 1
         lineCount: editor.getLineCount()
         percent: 100 * (bufpos.row + 1) / editor.getLineCount()
+        length: buffer.getText().length
 
   updatePosition: ->
     if stats = @getStats()
@@ -53,6 +54,7 @@ class CursorPositionView extends HTMLElement
         .replace('%C', stats.column)
         .replace('%l', stats.lineCount)
         .replace('%p', Math.round(stats.percent))
+        .replace('%z', stats.length) # BUG: doesn't update on backspace
     else
       @textContent = ''
 

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -33,28 +33,22 @@ class CursorPositionView extends HTMLElement
   getActiveTextEditor: ->
     atom.workspace.getActiveTextEditor()
 
-  getStats: ->
+  updatePosition: ->
     if editor = @getActiveTextEditor()
       screenpos = editor.getCursorScreenPosition()
       bufpos = editor.getCursorBufferPosition()
       buffer = editor.getBuffer()
-      stats =
-        line: bufpos.row + 1
-        column: screenpos.column + 1
-        lineCount: editor.getLineCount()
-        percent: 100 * (bufpos.row + 1) / editor.getLineCount()
-        length: buffer.getText().length
-
-  updatePosition: ->
-    if stats = @getStats()
-      @row = stats.line
-      @column = stats.column
+      @row = bufpos.row + 1
+      @column = screenpos.column + 1
+      @lineCount = editor.getLineCount()
+      @percent = Math.round(100 * @row / @lineCount)
+      @length = buffer.getText().length # BUG: doesn't update on backspace
       @textContent = @formatString
-        .replace('%L', stats.line)
-        .replace('%C', stats.column)
-        .replace('%l', stats.lineCount)
-        .replace('%p', Math.round(stats.percent))
-        .replace('%z', stats.length) # BUG: doesn't update on backspace
+        .replace('%L', @row)
+        .replace('%C', @column)
+        .replace('%l', @lineCount)
+        .replace('%p', @percent)
+        .replace('%z', @length)
     else
       @textContent = ''
 

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -36,27 +36,25 @@ class CursorPositionView extends HTMLElement
     atom.workspace.getActiveTextEditor()
 
   updatePosition: ->
-    if editor = @getActiveTextEditor()
-      screenpos = editor.getCursorScreenPosition()
-      bufpos = editor.getCursorBufferPosition()
-      @row = bufpos.row + 1
-      @column = screenpos.column + 1
-      @lineCount = editor.getLineCount()
-      @length = editor.getText().length
-      @offset = editor.getTextInBufferRange([[0, 1], bufpos]).length
-      @percent = Math.round(100 * @offset / @length)
-      @textContent = @formatString(@statusFormat)
-    else
-      @textContent = ''
+    @textContent = @formatString(@statusFormat)
 
   formatString: (str) ->
-    str
-      .replace('%L', @row)
-      .replace('%C', @column)
-      .replace('%l', @lineCount)
-      .replace('%z', @length)
-      .replace('%o', @offset)
-      .replace('%p', @percent)
-      .replace('\\n', '<br/>')
+    if editor = @getActiveTextEditor()
+      pos = editor.getCursorBufferPosition()
+      size = null
+      offset = null
+      str
+        .replace(/\\n/g, '<br/>')
+        .replace('%L', -> pos.row + 1)
+        .replace('%C', -> editor.getCursorScreenPosition().column + 1)
+        .replace('%l', -> editor.getLineCount())
+        .replace('%z', -> size = editor.getText().length)
+        .replace('%o', -> offset = editor.getTextInBufferRange([[0, 1], pos]).length)
+        .replace('%p', ->
+          size = size || editor.getText().length
+          offset = offset || editor.getTextInBufferRange([[0, 1], pos]).length
+          percent = Math.round(100 * offset / size))
+    else
+      ''
 
 module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -11,7 +11,8 @@ class CursorPositionView extends HTMLElement
     @subscribeToActiveTextEditor()
 
     @tooltip = atom.tooltips.add(this,
-      title: -> @formatString(@tooltipFormat))
+      title: -> @formatString(@tooltipFormat)
+      html: true)
 
   destroy: ->
     @activeItemSubscription.dispose()
@@ -56,5 +57,6 @@ class CursorPositionView extends HTMLElement
       .replace('%z', @length)
       .replace('%o', @offset)
       .replace('%p', @percent)
+      .replace('\\n', '<br/>')
 
 module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,11 +10,11 @@ module.exports =
     cursorPositionFormat:
       type: 'string'
       default: '%L:%C'
-      description: 'Format for the cursor position indicator'
+      description: 'Format of the cursor position indicator. See the README for a list of expansions.'
     cursorPositionTooltipFormat:
       type: 'string'
       default: 'Line %L, Column %C'
-      description: 'Format for the cursor position tooltip'
+      description: 'Format of the cursor position tooltip. See the README for a list of expansions.'
 
   activate: ->
     @statusBar = new StatusBarView()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,7 +10,11 @@ module.exports =
     cursorPositionFormat:
       type: 'string'
       default: '%L:%C'
-      description: 'Format for the cursor position status bar element, where %L is the line number and %C is the column number'
+      description: 'Format for the cursor position indicator'
+    cursorPositionTooltipFormat:
+      type: 'string'
+      default: 'Line %L, Column %C'
+      description: 'Format for the cursor position tooltip'
 
   activate: ->
     @statusBar = new StatusBarView()


### PR DESCRIPTION
This PR adds more display options for the cursor position view. This includes new interpolations in the format string and the ability to customize the tooltip.

It also fixes an issue where the column position would be wrong in files indented with hard tabs. The problem was that the column was calculated using the buffer position instead of the screen position.

This fixes #71.

**TODO:**
- [ ] Specs
- [ ] Lint