### PR TITLE
Add support for copying current path on click

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -2,9 +2,14 @@ class FileInfoView extends HTMLElement
   initialize: ->
     @classList.add('file-info', 'inline-block')
 
-    @currentPath = document.createElement('span')
+    @currentPath = document.createElement('a')
     @currentPath.classList.add('current-path')
+    @currentPath.href = '#'
     @appendChild(@currentPath)
+
+    @currentPath.addEventListener 'click', =>
+      if path = @getActiveItem()?.getPath?()
+        atom.clipboard.write(path)
 
     @bufferModified = document.createElement('span')
     @bufferModified.classList.add('buffer-modified')


### PR DESCRIPTION
... trying to implement https://github.com/atom/status-bar/issues/29  :sweat_smile: .

Currently WIP as displaying tooltip on click (step 2 from https://github.com/atom/status-bar/issues/29#issuecomment-48983644 by @lee-dohm) is not implemented and spec is missing too.

I am hoping someone can help with showing the tooltip with message "Copied!" when the path is clicked. The problem is that at the time element was clicked mouse already entered the element and when I create the tooltip, it won't be shown until I leave and reenter the tooltip again.

Things I tried:
* .. accessing `tooltip()` method to show the tooltip manually. I cannot find a way how to access the method as `TooltipManager` does. Getting `$` from `atom-space-pen-views` won't help as the `$(currentPath)` doesn't have the `tooltip()` method available although it still behaves like an jQuery object. Injecting Bootstrap's tooltip functionality [using the code from TooltipManager](https://github.com/atom/atom/blob/master/src/tooltip-manager.coffee#L106) is not helping either.
* manually triggering `$(@currentPath).trigger('focusin.tooltip')` won't trigger the tooltip handler even though Bootstrap [registered listener exactly on that event](https://github.com/twbs/bootstrap/blob/master/js/tooltip.js#L72). I debugged it to make sure that is the correct event name. jQuery behaves like there is noone interested in that event.

I have the feeling I am missing something very obvious but given my current level of jQuery and atom experience I am not surprised :innocent: .

Thanks for any help! :heart_eyes:

Current behavior:
![copy_path](https://cloud.githubusercontent.com/assets/1128248/8420339/b59b32b0-1ec1-11e5-9025-7535a2718735.gif)