### PR TITLE
Give all status bar links consistent styling

### DIFF
--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -13,6 +13,10 @@ status-bar {
   white-space: nowrap;
   min-width: -webkit-min-content;
 
+  a, a:hover {
+    color: @text-color;
+  }
+
   .flexbox-repaint-hack {
     padding: 0 @component-line-height/2;
     position: absolute;


### PR DESCRIPTION
Just noticed that as a consequence of https://github.com/atom/status-bar/pull/88, the color of the status bar tile changed.

### Before
<img width="75" alt="screenshot 2015-07-03 09 25 38" src="https://cloud.githubusercontent.com/assets/823545/8499934/a9696560-2165-11e5-93ea-e1c43721879f.png">

### After
<img width="144" alt="screenshot 2015-07-03 09 25 30" src="https://cloud.githubusercontent.com/assets/823545/8499935/ac08e304-2165-11e5-8fad-6b3eb911d64d.png">

This also provides the same default styling for any `a` elements in the status bar.