### PR TITLE
Apply buffer modified '*' via CSS, rather than a separate DOM element.

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -8,10 +8,6 @@ class FileInfoView extends HTMLElement
     @currentPath.classList.add('current-path')
     @appendChild(@currentPath)
 
-    @bufferModified = document.createElement('span')
-    @bufferModified.classList.add('buffer-modified')
-    @appendChild(@bufferModified)
-
     @handleCopiedTooltip()
 
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
@@ -73,10 +69,10 @@ class FileInfoView extends HTMLElement
 
   updateBufferHasModifiedText: (isModified) ->
     if isModified
-      @bufferModified.textContent = '*' unless @isModified
+      @classList.add('buffer-modified')
       @isModified = true
     else
-      @bufferModified.textContent = '' if @isModified
+      @classList.remove('buffer-modified')
       @isModified = false
 
   updatePathText: ->

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -110,10 +110,10 @@ describe "Built-in Status Bar Tiles", ->
 
     describe "when the associated editor's buffer's content changes", ->
       it "enables the buffer modified indicator", ->
-        expect(fileInfo.bufferModified.textContent).toBe ''
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
         editor.insertText("\n")
         advanceClock(buffer.stoppedChangingDelay)
-        expect(fileInfo.bufferModified.textContent).toBe '*'
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(true)
         editor.backspace()
 
     describe "when the buffer content has changed from the content on disk", ->
@@ -126,34 +126,34 @@ describe "Built-in Status Bar Tiles", ->
 
         runs ->
           editor = atom.workspace.getActiveTextEditor()
-          expect(fileInfo.bufferModified.textContent).toBe ''
+          expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
           editor.insertText("\n")
           advanceClock(buffer.stoppedChangingDelay)
-          expect(fileInfo.bufferModified.textContent).toBe '*'
+          expect(fileInfo.classList.contains('buffer-modified')).toBe(true)
           editor.getBuffer().save()
-          expect(fileInfo.bufferModified.textContent).toBe ''
+          expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
 
       it "disables the buffer modified indicator if the content matches again", ->
-        expect(fileInfo.bufferModified.textContent).toBe ''
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
         editor.insertText("\n")
         advanceClock(buffer.stoppedChangingDelay)
-        expect(fileInfo.bufferModified.textContent).toBe '*'
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(true)
         editor.backspace()
         advanceClock(buffer.stoppedChangingDelay)
-        expect(fileInfo.bufferModified.textContent).toBe ''
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
 
       it "disables the buffer modified indicator when the change is undone", ->
-        expect(fileInfo.bufferModified.textContent).toBe ''
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
         editor.insertText("\n")
         advanceClock(buffer.stoppedChangingDelay)
-        expect(fileInfo.bufferModified.textContent).toBe '*'
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(true)
         editor.undo()
         advanceClock(buffer.stoppedChangingDelay)
-        expect(fileInfo.bufferModified.textContent).toBe ''
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
 
     describe "when the buffer changes", ->
       it "updates the buffer modified indicator for the new buffer", ->
-        expect(fileInfo.bufferModified.textContent).toBe ''
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
 
         waitsForPromise ->
           atom.workspace.open('sample.txt')
@@ -162,11 +162,11 @@ describe "Built-in Status Bar Tiles", ->
           editor = atom.workspace.getActiveTextEditor()
           editor.insertText("\n")
           advanceClock(buffer.stoppedChangingDelay)
-          expect(fileInfo.bufferModified.textContent).toBe '*'
+          expect(fileInfo.classList.contains('buffer-modified')).toBe(true)
 
       it "doesn't update the buffer modified indicator for the old buffer", ->
         oldBuffer = editor.getBuffer()
-        expect(fileInfo.bufferModified.textContent).toBe ''
+        expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
 
         waitsForPromise ->
           atom.workspace.open('sample.txt')
@@ -174,7 +174,7 @@ describe "Built-in Status Bar Tiles", ->
         runs ->
           oldBuffer.setText("new text")
           advanceClock(buffer.stoppedChangingDelay)
-          expect(fileInfo.bufferModified.textContent).toBe ''
+          expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
 
     describe "when the associated editor's cursor position changes", ->
       it "updates the cursor position in the status bar", ->

--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -67,6 +67,10 @@ status-bar {
     max-width: none;
   }
 
+  .file-info.buffer-modified::after {
+    content: '*';
+  }
+
   // All icons are smaller than normal (normal is 16px)
   .icon:before {
     .icon-size(14px);
@@ -81,7 +85,6 @@ status-bar {
     margin-right: -1px;
   }
 
-  .buffer-modified:empty,
   .current-path:empty,
   .cursor-position:empty,
   .selection-count:empty {


### PR DESCRIPTION
This allows a little more flexibility in how one can style the
indicator. For example, one could change the character used, or
highlight the whole file name for more visual prominence.