### PR TITLE
Add indentation indicator and selector

### DIFF
--- a/lib/indentation-status-view.coffee
+++ b/lib/indentation-status-view.coffee
@@ -1,0 +1,100 @@
+{Disposable} = require 'atom'
+
+# View to show the grammar name in the status bar.
+class IndentationStatusView extends HTMLDivElement
+  initialize: (@statusBar) ->
+    @classList.add('indentation-status', 'inline-block')
+
+    @icon = document.createElement('span')
+    @icon.classList.add('inline-block')
+    @icon.style.marginRight = '5px'
+    @icon.textContent = '»'
+
+    @tabTypeLink = document.createElement('a')
+    @tabTypeLink.classList.add('inline-block', 'tabtype-selector')
+    @tabTypeLink.style.marginRight = '5px'
+    @tabTypeLink.href = '#'
+
+    @tabLengthLink = document.createElement('a')
+    @tabLengthLink.classList.add('inline-block', 'tabwidth-selector')
+    @tabLengthLink.href = '#'
+
+    @appendChild(@icon)
+    @appendChild(@tabTypeLink)
+    @appendChild(@tabLengthLink)
+    @handleEvents()
+    this
+
+  handleEvents: ->
+    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
+      @subscribeToPotentialEvents()
+
+    @tabTypeLink.addEventListener('click', @tabTypeToggle.bind(this))
+    @tabLengthLink.addEventListener('click', @tabWidthToggle.bind(this))
+
+    @tabTypeLinkClickSubscription = new Disposable => @tabTypeLink.removeEventListener('click', @tabTypeToggle)
+    @tabLengthLinkClickSubscription = new Disposable => @tabLengthLink.removeEventListener('click', @tabWidthToggle)
+
+    @subscribeToPotentialEvents()
+
+  destroy: ->
+    @activeItemSubscription?.dispose()
+    @userChangeSubscription?.dispose()
+    @tabTypeLinkClickSubscription?.dispose()
+    @tabLengthLinkClickSubscription?.dispose()
+    @configSubscription?.dispose()
+    @indentationConfigSubscription?.dispose()
+
+  getActiveTextEditor: ->
+    atom.workspace.getActiveTextEditor()
+
+  tabTypeToggle: (ev) ->
+    editor = @getActiveTextEditor()
+    # Get current value
+    softTabs = editor.getSoftTabs(editor.getRootScopeDescriptor())
+    # Toggle softTabs
+    editor.setSoftTabs(not softTabs, editor.getRootScopeDescriptor())
+    # console.log 'toggle softTabs to ' + (not softTabs)
+    # console.log 'now it is ' + editor.getSoftTabs()
+
+    # Update interface
+    @updateTabTypeText()
+
+  tabWidthToggle: (ev) ->
+    editor = @getActiveTextEditor()
+
+    tabWidth = editor.getTabLength(scope: editor.getRootScopeDescriptor())
+
+    # Iterate over fixed options
+    tabWidth += 2
+    if tabWidth > 8
+      tabWidth = 2
+
+    editor.setTabLength(tabWidth)
+    @updateTabWidthText()
+
+  subscribeToPotentialEvents: ->
+    @userChangeSubscription?.dispose()
+    @indentationConfigSubscription?.dispose()
+    @indentationConfigSubscription = atom.config.observe 'editor.tabType', =>
+      @updateTabTypeText()
+    # FIXME: Noisy channel subscription, change to better one
+    @userChangeSubscription = @getActiveTextEditor()?.onDidChange =>
+      @updateIndentationText()
+    @updateIndentationText()
+
+  updateIndentationText: ->
+    @updateTabTypeText()
+    @updateTabWidthText()
+
+  updateTabTypeText: ->
+    softTabs = @getActiveTextEditor()?.getSoftTabs()
+    @tabTypeLink.textContent = 'tab'
+    @tabTypeLink.textContent = 'space' if softTabs
+
+  updateTabWidthText: ->
+    tabwidth = @getActiveTextEditor()?.getTabLength()
+    # console.log 'update to ' + tabwidth
+    @tabLengthLink.textContent = tabwidth
+
+module.exports = document.registerElement('indentation-status', prototype: IndentationStatusView.prototype)

--- a/lib/indentation-status-view.coffee
+++ b/lib/indentation-status-view.coffee
@@ -95,12 +95,8 @@ class IndentationStatusView extends HTMLDivElement
     if editor
       softTabs = editor.getSoftTabs()
       if softTabs
-        @tabTypeLink.classList.remove('icon-chevron-right')
-        @tabTypeLink.classList.add('icon-primitive-dot')
         @tabTypeLink.textContent = 'Space'
       else
-        @tabTypeLink.classList.remove('icon-primitive-dot')
-        @tabTypeLink.classList.add('icon-chevron-right')
         @tabTypeLink.textContent = 'Tab'
     else
       @hide()

--- a/lib/indentation-status-view.coffee
+++ b/lib/indentation-status-view.coffee
@@ -26,7 +26,9 @@ class IndentationStatusView extends HTMLDivElement
     this
 
   handleEvents: ->
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
+    @activePaneSubscription = atom.workspace.onDidChangeActivePaneItem =>
+      if @getActiveTextEditor()
+        @show()
       @subscribeToPotentialEvents()
 
     @tabTypeLink.addEventListener('click', @tabTypeToggle.bind(this))
@@ -37,8 +39,15 @@ class IndentationStatusView extends HTMLDivElement
 
     @subscribeToPotentialEvents()
 
+  hide: ->
+    @style.display = 'none'
+
+  show: ->
+    @style.display = ''
+
   destroy: ->
-    @activeItemSubscription?.dispose()
+    @activePaneSubscription?.dispose()
+    @destroyPaneSubscription?.dispose()
     @userChangeSubscription?.dispose()
     @tabTypeLinkClickSubscription?.dispose()
     @tabLengthLinkClickSubscription?.dispose()
@@ -88,12 +97,21 @@ class IndentationStatusView extends HTMLDivElement
     @updateTabWidthText()
 
   updateTabTypeText: ->
-    softTabs = @getActiveTextEditor()?.getSoftTabs()
-    @tabTypeLink.textContent = 'tab'
-    @tabTypeLink.textContent = 'space' if softTabs
+    editor = @getActiveTextEditor()
+    if editor
+      softTabs = editor.getSoftTabs()
+      tabType = 'tab'
+      tabType = 'space' if softTabs
+    else
+      @hide()
+    @tabTypeLink.textContent = tabType
 
   updateTabWidthText: ->
-    tabwidth = @getActiveTextEditor()?.getTabLength()
+    editor = @getActiveTextEditor()
+    if editor
+      tabwidth = editor.getTabLength()
+    else
+      @hide()
     # console.log 'update to ' + tabwidth
     @tabLengthLink.textContent = tabwidth
 

--- a/lib/indentation-status-view.coffee
+++ b/lib/indentation-status-view.coffee
@@ -5,13 +5,8 @@ class IndentationStatusView extends HTMLDivElement
   initialize: (@statusBar) ->
     @classList.add('indentation-status', 'inline-block')
 
-    @icon = document.createElement('span')
-    @icon.classList.add('inline-block')
-    @icon.style.marginRight = '5px'
-    @icon.textContent = '»'
-
     @tabTypeLink = document.createElement('a')
-    @tabTypeLink.classList.add('inline-block', 'tabtype-selector')
+    @tabTypeLink.classList.add('inline-block', 'icon', 'tabtype-selector')
     @tabTypeLink.style.marginRight = '5px'
     @tabTypeLink.href = '#'
 
@@ -19,7 +14,6 @@ class IndentationStatusView extends HTMLDivElement
     @tabLengthLink.classList.add('inline-block', 'tabwidth-selector')
     @tabLengthLink.href = '#'
 
-    @appendChild(@icon)
     @appendChild(@tabTypeLink)
     @appendChild(@tabLengthLink)
     @handleEvents()
@@ -100,11 +94,16 @@ class IndentationStatusView extends HTMLDivElement
     editor = @getActiveTextEditor()
     if editor
       softTabs = editor.getSoftTabs()
-      tabType = 'tab'
-      tabType = 'space' if softTabs
+      if softTabs
+        @tabTypeLink.classList.remove('icon-chevron-right')
+        @tabTypeLink.classList.add('icon-primitive-dot')
+        @tabTypeLink.textContent = 'Space'
+      else
+        @tabTypeLink.classList.remove('icon-primitive-dot')
+        @tabTypeLink.classList.add('icon-chevron-right')
+        @tabTypeLink.textContent = 'Tab'
     else
       @hide()
-    @tabTypeLink.textContent = tabType
 
   updateTabWidthText: ->
     editor = @getActiveTextEditor()
@@ -113,6 +112,6 @@ class IndentationStatusView extends HTMLDivElement
     else
       @hide()
     # console.log 'update to ' + tabwidth
-    @tabLengthLink.textContent = tabwidth
+    @tabLengthLink.textContent = '[ ' + tabwidth + ' ]'
 
 module.exports = document.registerElement('indentation-status', prototype: IndentationStatusView.prototype)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,6 +3,7 @@ StatusBarView = require './status-bar-view'
 FileInfoView = require './file-info-view'
 CursorPositionView = require './cursor-position-view'
 SelectionCountView = require './selection-count-view'
+IndentationStatusView = require './indentation-status-view'
 GitView = require './git-view'
 
 module.exports =
@@ -96,6 +97,10 @@ module.exports =
     @git = new GitView()
     @git.initialize()
     @statusBar.addRightTile(item: @git, priority: 0)
+
+    @indent = new IndentationStatusView()
+    @indent.initialize(@statusbar)
+    @statusBar.addRightTile(item: @indent, priority: 1)
 
   deactivate: ->
     @git?.destroy()

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -276,7 +276,7 @@ describe "Built-in Status Bar Tiles", ->
     gitView = null
 
     beforeEach ->
-      [gitView] = statusBar.getRightTiles().map (tile) -> tile.getItem()
+      gitView = statusBar.querySelector('.git-view')
 
     describe "the git branch label", ->
       beforeEach ->
@@ -410,3 +410,145 @@ describe "Built-in Status Bar Tiles", ->
 
         runs ->
           expect(gitView.gitStatusIcon).toBeHidden()
+
+  describe "indentation status tile", ->
+    [editor, editorView, workspaceElement] =  []
+    [indentationStatus, tabTypeSelector, tabLengthSelector, locateElements] = []
+
+    locateElements = ->
+      indentationStatus = statusBar.querySelector('.indentation-status')
+      tabTypeSelector = indentationStatus.querySelector('.tabtype-selector')
+      tabLengthSelector = indentationStatus.querySelector('.tabwidth-selector')
+
+    beforeEach ->
+      workspaceElement = atom.views.getView(atom.workspace)
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-text')
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-javascript')
+
+      waitsForPromise ->
+        atom.workspace.open('sample.js')
+
+      runs ->
+        editor = atom.workspace.getActiveTextEditor()
+        editorView = atom.views.getView(editor)
+        textGrammar = atom.grammars.grammarForScopeName('text.plain')
+        expect(textGrammar).toBeTruthy()
+        jsGrammar = atom.grammars.grammarForScopeName('source.js')
+        expect(jsGrammar).toBeTruthy()
+        expect(editor.getGrammar()).toBe jsGrammar
+
+    describe "when first displayed on status bar", ->
+
+      beforeEach ->
+        locateElements()
+
+      describe "when editor.tabType is auto", ->
+        beforeEach ->
+          atom.config.set('editor.tabType', 'auto')
+
+        it "display indentation type based on auto detection", ->
+          expect(tabTypeSelector.textContent).toBe 'space'
+
+      describe "when editor.tabType is not auto", ->
+        it "display indentation type specified in config", ->
+          # Soft configured
+          atom.config.set('editor.tabType', 'soft')
+          expect(tabTypeSelector.textContent).toBe 'space'
+
+          # Hard configured
+          atom.config.set('editor.tabType', 'hard')
+          expect(tabTypeSelector.textContent).toBe 'tab'
+
+      it "display current tabLength value", ->
+        tabLengthFromConfig = atom.config.get('editor.tabLength').toString()
+        expect(tabLengthSelector.textContent).toBe tabLengthFromConfig
+
+    describe "when softTabs toggled by user", ->
+      beforeEach ->
+        locateElements()
+
+      it "displays the current state", ->
+        atom.config.set('editor.tabType', 'hard', scope: editor.getRootScopeDescriptor())
+
+        expect(tabTypeSelector.textContent).toBe 'tab'
+
+        editor.toggleSoftTabs()
+        # FIXME: Signal emitted only when editor changed it's content
+        editor.insertText(' ')
+        editor.delete()
+        expect(tabTypeSelector.textContent).toBe 'space'
+
+        editor.toggleSoftTabs()
+        # FIXME: Signal emitted only when editor changed it's content
+        editor.insertText(' ')
+        editor.delete()
+        expect(tabTypeSelector.textContent).toBe 'tab'
+
+    describe "when tabLength config changed by user", ->
+      beforeEach ->
+        locateElements()
+
+      it "display correct tabLength state", ->
+        atom.config.set('editor.tabLength', 2)
+        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+
+        atom.config.set('editor.tabLength', 4)
+        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+
+        atom.config.set('editor.tabLength', 8)
+        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+
+    describe "when tabLength modified through setTabLength()", ->
+      beforeEach ->
+        locateElements()
+
+      it "display correct tabLength state", ->
+        editor.setTabLength(2)
+        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+
+        editor.setTabLength(4)
+        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+
+        editor.setTabLength(8)
+        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+
+    describe "when indentation-selector toggled", ->
+      beforeEach ->
+        locateElements()
+
+      describe "when tabTypeSelector toggled", ->
+        it "change the displayed info", ->
+          tabTypeSelector.click()
+          expect(tabTypeSelector.textContent).toBe 'tab'
+
+          tabTypeSelector.click()
+          expect(tabTypeSelector.textContent).toBe 'space'
+
+        it "change editor softTabs property", ->
+          tabTypeSelector.click()
+          expect(editor.getSoftTabs()).toBe false
+
+          tabTypeSelector.click()
+          expect(editor.getSoftTabs()).toBe true
+
+      describe "when tabLengthSelector toggled", ->
+        it "change the displayed info", ->
+          tabLengthSelector.click()
+          expect(tabLengthSelector.textContent).toBe '4'
+
+          tabLengthSelector.click()
+          expect(tabLengthSelector.textContent).toBe '6'
+
+          tabLengthSelector.click()
+          expect(tabLengthSelector.textContent).toBe '8'
+
+        it "change editor softTabs property", ->
+          tabTypeSelector.click()
+          expect(editor.getSoftTabs()).toBe false
+
+          tabTypeSelector.click()
+          expect(editor.getSoftTabs()).toBe true

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -420,6 +420,12 @@ describe "Built-in Status Bar Tiles", ->
       tabTypeSelector = indentationStatus.querySelector('.tabtype-selector')
       tabLengthSelector = indentationStatus.querySelector('.tabwidth-selector')
 
+    formatTabTypeInfo = (tabType) ->
+      return tabType[0].toUpperCase() + tabType.substr(1)
+
+    formatTabLengthInfo = (tabLength) ->
+      return '[ ' + tabLength.toString() + ' ]'
+
     beforeEach ->
       workspaceElement = atom.views.getView(atom.workspace)
 
@@ -451,21 +457,21 @@ describe "Built-in Status Bar Tiles", ->
           atom.config.set('editor.tabType', 'auto')
 
         it "display indentation type based on auto detection", ->
-          expect(tabTypeSelector.textContent).toBe 'space'
+          expect(tabTypeSelector.textContent).toBe formatTabTypeInfo('space')
 
       describe "when editor.tabType is not auto", ->
         it "display indentation type specified in config", ->
           # Soft configured
           atom.config.set('editor.tabType', 'soft')
-          expect(tabTypeSelector.textContent).toBe 'space'
+          expect(tabTypeSelector.textContent).toBe formatTabTypeInfo('space')
 
           # Hard configured
           atom.config.set('editor.tabType', 'hard')
-          expect(tabTypeSelector.textContent).toBe 'tab'
+          expect(tabTypeSelector.textContent).toBe formatTabTypeInfo('tab')
 
       it "display current tabLength value", ->
         tabLengthFromConfig = atom.config.get('editor.tabLength').toString()
-        expect(tabLengthSelector.textContent).toBe tabLengthFromConfig
+        expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(tabLengthFromConfig)
 
     describe "when softTabs toggled by user", ->
       beforeEach ->
@@ -474,19 +480,19 @@ describe "Built-in Status Bar Tiles", ->
       it "displays the current state", ->
         atom.config.set('editor.tabType', 'hard', scope: editor.getRootScopeDescriptor())
 
-        expect(tabTypeSelector.textContent).toBe 'tab'
+        expect(tabTypeSelector.textContent).toBe formatTabTypeInfo('tab')
 
         editor.toggleSoftTabs()
         # FIXME: Signal emitted only when editor changed it's content
         editor.insertText(' ')
         editor.delete()
-        expect(tabTypeSelector.textContent).toBe 'space'
+        expect(tabTypeSelector.textContent).toBe formatTabTypeInfo('space')
 
         editor.toggleSoftTabs()
         # FIXME: Signal emitted only when editor changed it's content
         editor.insertText(' ')
         editor.delete()
-        expect(tabTypeSelector.textContent).toBe 'tab'
+        expect(tabTypeSelector.textContent).toBe formatTabTypeInfo('tab')
 
     describe "when tabLength config changed by user", ->
       beforeEach ->
@@ -494,13 +500,13 @@ describe "Built-in Status Bar Tiles", ->
 
       it "display correct tabLength state", ->
         atom.config.set('editor.tabLength', 2)
-        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+        expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(editor.getTabLength())
 
         atom.config.set('editor.tabLength', 4)
-        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+        expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(editor.getTabLength())
 
         atom.config.set('editor.tabLength', 8)
-        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+        expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(editor.getTabLength())
 
     describe "when tabLength modified through setTabLength()", ->
       beforeEach ->
@@ -508,13 +514,13 @@ describe "Built-in Status Bar Tiles", ->
 
       it "display correct tabLength state", ->
         editor.setTabLength(2)
-        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+        expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(editor.getTabLength())
 
         editor.setTabLength(4)
-        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+        expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(editor.getTabLength())
 
         editor.setTabLength(8)
-        expect(tabLengthSelector.textContent).toBe editor.getTabLength().toString()
+        expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(editor.getTabLength())
 
     describe "when indentation-selector toggled", ->
       beforeEach ->
@@ -523,10 +529,10 @@ describe "Built-in Status Bar Tiles", ->
       describe "when tabTypeSelector toggled", ->
         it "change the displayed info", ->
           tabTypeSelector.click()
-          expect(tabTypeSelector.textContent).toBe 'tab'
+          expect(tabTypeSelector.textContent).toBe formatTabTypeInfo('tab')
 
           tabTypeSelector.click()
-          expect(tabTypeSelector.textContent).toBe 'space'
+          expect(tabTypeSelector.textContent).toBe formatTabTypeInfo('space')
 
         it "change editor softTabs property", ->
           tabTypeSelector.click()
@@ -538,13 +544,13 @@ describe "Built-in Status Bar Tiles", ->
       describe "when tabLengthSelector toggled", ->
         it "change the displayed info", ->
           tabLengthSelector.click()
-          expect(tabLengthSelector.textContent).toBe '4'
+          expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(4)
 
           tabLengthSelector.click()
-          expect(tabLengthSelector.textContent).toBe '6'
+          expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(6)
 
           tabLengthSelector.click()
-          expect(tabLengthSelector.textContent).toBe '8'
+          expect(tabLengthSelector.textContent).toBe formatTabLengthInfo(8)
 
         it "change editor softTabs property", ->
           tabTypeSelector.click()


### PR DESCRIPTION
The indicator include tile for customizing `tabType` and `tabLength`. The tile purposely using toggle link interface to switch between option.

Trying to solve issue #36.
