### PR TITLE
Copy the path part of an item's url path, or just the path as is if not a url

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -15,7 +15,7 @@ class FileInfoView extends HTMLElement
     @subscribeToActiveItem()
 
     clickHandler = =>
-      text = @getActiveItem()?.getPath?() or @getActiveItem()?.getTitle?() or ''
+      text = @getActiveItemCopyText()
       atom.clipboard.write(text)
       setTimeout =>
         @handleCopiedTooltip()
@@ -26,12 +26,16 @@ class FileInfoView extends HTMLElement
 
   handleCopiedTooltip: ->
     @copiedTooltip?.dispose()
-    text = @getActiveItem()?.getPath?() or @getActiveItem()?.getTitle?() or ''
+    text = @getActiveItemCopyText()
     @copiedTooltip = atom.tooltips.add this,
       title: "Copied: #{text}"
       trigger: 'click'
       delay:
         show: 0
+
+  getActiveItemCopyText: ->
+    # An item path could be a url, but we only want to copy the `path` part of it.
+    require('url').parse(@getActiveItem()?.getPath?() or '').path or @getActiveItem()?.getTitle?() or ''
 
   subscribeToActiveItem: ->
     @modifiedSubscription?.dispose()

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -48,6 +48,24 @@ describe "Built-in Status Bar Tiles", ->
         runs ->
           expect(fileInfo.currentPath.textContent).toBe 'sample.txt'
 
+    describe "when associated with remote file path", ->
+      [remotePath] = []
+
+      beforeEach ->
+        remotePath = 'remote://server:123/folder/remote_file.txt'
+        jasmine.attachToDOM(workspaceElement)
+        dummyView.getPath = -> remotePath
+        atom.workspace.getActivePane().activateItem(dummyView)
+
+      it "updates the path in the status bar", ->
+        # The remote path isn't relativized in the test because no remote directory provider is registered.
+        expect(fileInfo.currentPath.textContent).toBe remotePath
+        expect(fileInfo.currentPath).toBeVisible()
+
+      it "when the path is clicked", ->
+        fileInfo.currentPath.click()
+        expect(atom.clipboard.read()).toBe '/folder/remote_file.txt'
+
     describe "when buffer's path is clicked", ->
       it "copies the absolute path into the clipboard if available", ->
         waitsForPromise ->


### PR DESCRIPTION
While editing remote file in Nuclide have paths like:
`nuclide://server:port/$absoluteFilePath`, clicking the file name on the status bar copies the full url, where it should only be copying the `$absoluteFilePath` part.

Test: I manually verified that the new behavior works for both local and remote file paths.

@kevinsawicki @bolinfest 