### PR TITLE
Add tooltips to git views

### DIFF
--- a/lib/git-view.coffee
+++ b/lib/git-view.coffee
@@ -125,7 +125,7 @@ class GitView extends HTMLElement
         @commitsAhead.textContent = ahead
         @commitsAhead.style.display = ''
         @commitsAheadTooltipDisposable?.dispose()
-        @commitsAheadTooltipDisposable = atom.tooltips.add @commitsAhead, title: "#{_.pluralize(ahead, 'commit')} commits ahead of upstream"
+        @commitsAheadTooltipDisposable = atom.tooltips.add @commitsAhead, title: "#{_.pluralize(ahead, 'commit')} ahead of upstream"
       else
         @commitsAhead.style.display = 'none'
 
@@ -161,7 +161,7 @@ class GitView extends HTMLElement
         tooltipText = "#{_.pluralize(stats.added, 'line')} added to this file not yet committed"
       else if stats.deleted
         @gitStatusIcon.textContent = "-#{stats.deleted}"
-        tooltipText = "#{_.pluralize(stats.deleted, 'line')} lines added from this file not yet committed"
+        tooltipText = "#{_.pluralize(stats.deleted, 'line')} added from this file not yet committed"
       else
         @gitStatusIcon.textContent = ''
       @gitStatus.style.display = ''

--- a/lib/git-view.coffee
+++ b/lib/git-view.coffee
@@ -1,3 +1,4 @@
+_ = require "underscore-plus"
 {CompositeDisposable} = require "atom"
 
 class GitView extends HTMLElement
@@ -124,7 +125,7 @@ class GitView extends HTMLElement
         @commitsAhead.textContent = ahead
         @commitsAhead.style.display = ''
         @commitsAheadTooltipDisposable?.dispose()
-        @commitsAheadTooltipDisposable = atom.tooltips.add @commitsAhead, title: "#{ahead} commits ahead of upstream"
+        @commitsAheadTooltipDisposable = atom.tooltips.add @commitsAhead, title: "#{_.pluralize(ahead, 'commit')} commits ahead of upstream"
       else
         @commitsAhead.style.display = 'none'
 
@@ -132,7 +133,7 @@ class GitView extends HTMLElement
         @commitsBehind.textContent = behind
         @commitsBehind.style.display = ''
         @commitsBehindTooltipDisposable?.dispose()
-        @commitsBehindTooltipDisposable = atom.tooltips.add @commitsBehind, title: "#{behind} commits behind upstream"
+        @commitsBehindTooltipDisposable = atom.tooltips.add @commitsBehind, title: "#{_.pluralize(behind, 'commit')} behind upstream"
       else
         @commitsBehind.style.display = 'none'
 
@@ -154,13 +155,13 @@ class GitView extends HTMLElement
       stats = repo.getDiffStats(itemPath)
       if stats.added and stats.deleted
         @gitStatusIcon.textContent = "+#{stats.added}, -#{stats.deleted}"
-        tooltipText = "#{stats.added} lines added and -#{stats.deleted} lines deleted in this file not yet committed"
+        tooltipText = "#{_.pluralize(stats.added, 'line')} added and #{_.pluralize(stats.deleted, 'line')} deleted in this file not yet committed"
       else if stats.added
         @gitStatusIcon.textContent = "+#{stats.added}"
-        tooltipText = "#{stats.added} lines added to this file not yet committed"
+        tooltipText = "#{_.pluralize(stats.added, 'line')} added to this file not yet committed"
       else if stats.deleted
         @gitStatusIcon.textContent = "-#{stats.deleted}"
-        tooltipText = "#{stats.added} lines added from this file not yet committed"
+        tooltipText = "#{_.pluralize(stats.deleted, 'line')} lines added from this file not yet committed"
       else
         @gitStatusIcon.textContent = ''
       @gitStatus.style.display = ''
@@ -168,7 +169,7 @@ class GitView extends HTMLElement
       @gitStatusIcon.classList.add('icon-diff-added', 'status-added')
       if textEditor = atom.workspace.getActiveTextEditor()
         @gitStatusIcon.textContent = "+#{textEditor.getLineCount()}"
-        tooltipText = "#{textEditor.getLineCount()} lines in this new file not yet committed"
+        tooltipText = "#{_.pluralize(textEditor.getLineCount(), 'line')} in this new file not yet committed"
       else
         @gitStatusIcon.textContent = ''
       @gitStatus.style.display = ''

--- a/lib/git-view.coffee
+++ b/lib/git-view.coffee
@@ -73,6 +73,10 @@ class GitView extends HTMLElement
     @projectPathSubscription?.dispose()
     @savedSubscription?.dispose()
     @repositorySubscriptions?.dispose()
+    @branchTooltipDisposable?.dispose()
+    @commitsAheadTooltipDisposable?.dispose()
+    @commitsBehindTooltipDisposable?.dispose()
+    @statusTooltipDisposable?.dispose()
 
   getActiveItemPath: ->
     @getActiveItem()?.getPath?()
@@ -101,6 +105,8 @@ class GitView extends HTMLElement
       head = repo?.getShortHead(@getActiveItemPath()) or ''
       @branchLabel.textContent = head
       @branchArea.style.display = '' if head
+      @branchTooltipDisposable?.dispose()
+      @branchTooltipDisposable = atom.tooltips.add @branchArea, title: "On branch #{head}"
 
   showBranchInformation: ->
     if itemPath = @getActiveItemPath()
@@ -117,12 +123,16 @@ class GitView extends HTMLElement
       if ahead > 0
         @commitsAhead.textContent = ahead
         @commitsAhead.style.display = ''
+        @commitsAheadTooltipDisposable?.dispose()
+        @commitsAheadTooltipDisposable = atom.tooltips.add @commitsAhead, title: "#{ahead} commits ahead of upstream"
       else
         @commitsAhead.style.display = 'none'
 
       if behind > 0
         @commitsBehind.textContent = behind
         @commitsBehind.style.display = ''
+        @commitsBehindTooltipDisposable?.dispose()
+        @commitsBehindTooltipDisposable = atom.tooltips.add @commitsBehind, title: "#{behind} commits behind upstream"
       else
         @commitsBehind.style.display = 'none'
 
@@ -137,15 +147,20 @@ class GitView extends HTMLElement
     status = repo?.getCachedPathStatus(itemPath) ? 0
     @gitStatusIcon.classList.remove('icon-diff-modified', 'status-modified', 'icon-diff-added', 'status-added', 'icon-diff-ignored', 'status-ignored')
 
+    tooltipText = null;
+
     if repo?.isStatusModified(status)
       @gitStatusIcon.classList.add('icon-diff-modified', 'status-modified')
       stats = repo.getDiffStats(itemPath)
       if stats.added and stats.deleted
         @gitStatusIcon.textContent = "+#{stats.added}, -#{stats.deleted}"
+        tooltipText = "#{stats.added} lines added and -#{stats.deleted} lines deleted in this file not yet committed"
       else if stats.added
         @gitStatusIcon.textContent = "+#{stats.added}"
+        tooltipText = "#{stats.added} lines added to this file not yet committed"
       else if stats.deleted
         @gitStatusIcon.textContent = "-#{stats.deleted}"
+        tooltipText = "#{stats.added} lines added from this file not yet committed"
       else
         @gitStatusIcon.textContent = ''
       @gitStatus.style.display = ''
@@ -153,14 +168,20 @@ class GitView extends HTMLElement
       @gitStatusIcon.classList.add('icon-diff-added', 'status-added')
       if textEditor = atom.workspace.getActiveTextEditor()
         @gitStatusIcon.textContent = "+#{textEditor.getLineCount()}"
+        tooltipText = "#{textEditor.getLineCount()} lines in this new file not yet committed"
       else
         @gitStatusIcon.textContent = ''
       @gitStatus.style.display = ''
     else if repo?.isPathIgnored(itemPath)
       @gitStatusIcon.classList.add('icon-diff-ignored',  'status-ignored')
+      tooltipText = "File is ignored by git"
       @gitStatusIcon.textContent = ''
       @gitStatus.style.display = ''
     else
       @gitStatus.style.display = 'none'
+
+    @statusTooltipDisposable?.dispose()
+    if tooltipText
+      @statusTooltipDisposable = atom.tooltips.add @gitStatusIcon, title: tooltipText
 
 module.exports = document.registerElement('status-bar-git', prototype: GitView.prototype, extends: 'div')

--- a/lib/git-view.coffee
+++ b/lib/git-view.coffee
@@ -147,7 +147,7 @@ class GitView extends HTMLElement
     status = repo?.getCachedPathStatus(itemPath) ? 0
     @gitStatusIcon.classList.remove('icon-diff-modified', 'status-modified', 'icon-diff-added', 'status-added', 'icon-diff-ignored', 'status-ignored')
 
-    tooltipText = null;
+    tooltipText = null
 
     if repo?.isStatusModified(status)
       @gitStatusIcon.classList.add('icon-diff-modified', 'status-modified')

--- a/lib/launch-mode-view.coffee
+++ b/lib/launch-mode-view.coffee
@@ -3,10 +3,10 @@ class LaunchModeView extends HTMLElement
     @classList.add('inline-block', 'icon', 'icon-color-mode')
     if devMode
       @classList.add('text-error')
-      @tooltipDisposable = atom.tooltips.add(this, title: 'This window is in dev mode.')
+      @tooltipDisposable = atom.tooltips.add(this, title: 'This window is in dev mode')
     else if safeMode
       @classList.add('text-success')
-      @tooltipDisposable = atom.tooltips.add(this, title: 'This window is in safe mode.')
+      @tooltipDisposable = atom.tooltips.add(this, title: 'This window is in safe mode')
 
   detachedCallback: ->
     @tooltipDisposable?.dispose()


### PR DESCRIPTION
Fixes #81 

![status_bar_tooltips](https://cloud.githubusercontent.com/assets/2193314/11166773/1a8818ba-8afa-11e5-9d47-84221fa2087a.png)
