### PR TITLE
Remove jQuery

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -21,53 +21,6 @@ module.exports =
     @statusBar.initialize()
     @statusBarPanel = atom.workspace.addBottomPanel(item: @statusBar, priority: 0)
 
-    if Grim.includeDeprecatedAPIs
-      {$} = require 'atom-space-pen-views'
-      # Wrap status bar element in a jQuery wrapper for backwards compatibility
-      wrappedStatusBar = $.extend $(@statusBar),
-        appendLeft: (view) =>
-          Grim.deprecate("Use ::addLeftTile({item, priority}) instead.")
-          @statusBar.appendLeft(view)
-
-        appendRight: (view) =>
-          Grim.deprecate("Use ::addRightTile({item, priority}) instead.")
-          @statusBar.appendRight(view)
-
-        prependLeft: (view) =>
-          Grim.deprecate("Use ::addLeftTile({item, priority}) instead.")
-          @statusBar.prependLeft(view)
-
-        prependRight: (view) =>
-          Grim.deprecate("Use ::addRightTile({item, priority}) instead.")
-          @statusBar.prependRight(view)
-
-        getActiveBuffer: =>
-          Grim.deprecate("Use atom.workspace.getActiveTextEditor() instead.")
-          @statusBar.getActiveBuffer()
-
-        getActiveItem: =>
-          Grim.deprecate("Use atom.workspace.getActivePaneItem() instead.")
-          @statusBar.getActiveItem()
-
-        subscribeToBuffer: (event, callback) =>
-          Grim.deprecate("Subscribe to TextEditor events instead.")
-          @statusBar.subscribeToBuffer(event, callback)
-
-      if atom.__workspaceView?
-        Object.defineProperty atom.__workspaceView, 'statusBar',
-          get: ->
-            Grim.deprecate """
-              The atom.workspaceView.statusBar global is deprecated. The global was
-              previously being assigned by the status-bar package, but Atom packages
-              should never assign globals.
-
-              In the future, this problem will be solved by an inter-package communication
-              API available on `atom.services`. For now, you can get a reference to the
-              `status-bar` element via `document.querySelector('status-bar')`.
-            """
-            wrappedStatusBar
-          configurable: true
-
     atom.commands.add 'atom-workspace', 'status-bar:toggle', =>
       if @statusBarPanel.isVisible()
         @statusBarPanel.hide()

--- a/lib/status-bar-view.coffee
+++ b/lib/status-bar-view.coffee
@@ -1,4 +1,3 @@
-{$} = require 'atom-space-pen-views'
 {Disposable} = require 'atom'
 Tile = require './tile'
 
@@ -76,13 +75,6 @@ class StatusBarView extends HTMLElement
 
   getRightTiles: ->
     @rightTiles
-
-  # Deprecated
-
-  appendLeft: (view) -> $(@leftPanel).append(view)
-  prependLeft: (view) -> $(@leftPanel).prepend(view)
-  appendRight: (view) -> $(@rightPanel).append(view)
-  prependRight: (view) -> $(@rightPanel).prepend(view)
 
   getActiveBuffer: ->
     @buffer

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "fs-plus": "^2.0.0",
     "grim": "^1.0.0",
-    "atom-space-pen-views": "^2.0.0",
     "underscore-plus": "^1.0.0"
   },
   "providedServices": {
@@ -24,6 +23,7 @@
     }
   },
   "devDependencies": {
+    "atom-space-pen-views": "^2.0.0",
     "coffeelint": "^1.9.7"
   }
 }


### PR DESCRIPTION
Apparently this package wasn't making use of atom-space-pen-views anymore, except for maintaining backwards compatibility.

I _think_ it's now safe to avoid supporting `__workspaceView__`, as a significant amount of time has elapsed since that global was removed.

/cc: @nathansobo