### PR TITLE
title with explanation for git commits ahead/before

### DIFF
--- a/lib/git-view.coffee
+++ b/lib/git-view.coffee
@@ -116,12 +116,14 @@ class GitView extends HTMLElement
 
       if ahead > 0
         @commitsAhead.textContent = ahead
+        @commitsAhead.title = "#{ahead} commits ahead"
         @commitsAhead.style.display = ''
       else
         @commitsAhead.style.display = 'none'
 
       if behind > 0
         @commitsBehind.textContent = behind
+        @commitsBehind.title = "#{behind} commits behind"
         @commitsBehind.style.display = ''
       else
         @commitsBehind.style.display = 'none'


### PR DESCRIPTION
I tend to confuse the :arrow_up:`number` indicator with package updates, so I've added a `title` explanation:

<img width="435" alt="screen shot 2015-11-11 at 3 52 41 pm" src="https://cloud.githubusercontent.com/assets/1190974/11100222/b5f8d01e-888e-11e5-86aa-19dd8dfaccf3.png">

There may be more places in which this could be useful, I guess - feel free to suggest them if you want a more complete implementation :)