### PR TITLE
Make shift clicks on the currentPath element copy the relative path

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -14,9 +14,9 @@ class FileInfoView extends HTMLElement
     @subscribeToActiveItem()
 
     clickHandler = (event) =>
-      altClick = if process.platform is 'darwin' then event.metaKey else event.ctrlKey
-      @showCopiedTooltip(altClick)
-      text = @getActiveItemCopyText(altClick)
+      isShiftClick = event.shiftKey
+      @showCopiedTooltip(isShiftClick)
+      text = @getActiveItemCopyText(isShiftClick)
       atom.clipboard.write(text)
       setTimeout =>
         @clearCopiedTooltip()
@@ -28,21 +28,21 @@ class FileInfoView extends HTMLElement
   clearCopiedTooltip: ->
     @copiedTooltip?.dispose()
 
-  showCopiedTooltip: (altClick) ->
+  showCopiedTooltip: (isShiftClick) ->
     @copiedTooltip?.dispose()
-    text = @getActiveItemCopyText(altClick)
+    text = @getActiveItemCopyText(isShiftClick)
     @copiedTooltip = atom.tooltips.add this,
       title: "Copied: #{text}"
       trigger: 'click'
       delay:
         show: 0
 
-  getActiveItemCopyText: (altClick) ->
+  getActiveItemCopyText: (isShiftClick) ->
     activeItem = @getActiveItem()
     # An item path could be a url, but we only want to copy the `path` part of it.
     path = url.parse(activeItem?.getPath?() or '').path or activeItem?.getTitle?() or ''
 
-    if altClick
+    if isShiftClick
       atom.project.relativize(path)
     else
       path

--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -14,7 +14,7 @@ class FileInfoView extends HTMLElement
     @subscribeToActiveItem()
 
     clickHandler = (event) =>
-      altClick = if process.platform == 'darwin' then event.metaKey else event.ctrlKey
+      altClick = if process.platform is 'darwin' then event.metaKey else event.ctrlKey
       @showCopiedTooltip(altClick)
       text = @getActiveItemCopyText(altClick)
       atom.clipboard.write(text)

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -72,6 +72,16 @@ describe "Built-in Status Bar Tiles", ->
           fileInfo.currentPath.click()
           expect(atom.clipboard.read()).toBe fileInfo.getActiveItem().getPath()
 
+    describe "when buffer's path is ctrl/meta clicked", ->
+      it "copies the relative path into the clipboard if available", ->
+        waitsForPromise ->
+          atom.workspace.open('sample.txt')
+
+        runs ->
+          event = new MouseEvent('click', metaKey: true, ctrlKey: true)
+          fileInfo.currentPath.dispatchEvent(event)
+          expect(atom.clipboard.read()).toBe 'sample.txt'
+
     describe "when path of an unsaved buffer is clicked", ->
       it "copies the 'untitled' into clipboard", ->
         waitsForPromise ->

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -72,13 +72,13 @@ describe "Built-in Status Bar Tiles", ->
           fileInfo.currentPath.click()
           expect(atom.clipboard.read()).toBe fileInfo.getActiveItem().getPath()
 
-    describe "when buffer's path is ctrl/meta clicked", ->
+    describe "when buffer's path is shift-clicked", ->
       it "copies the relative path into the clipboard if available", ->
         waitsForPromise ->
           atom.workspace.open('sample.txt')
 
         runs ->
-          event = new MouseEvent('click', metaKey: true, ctrlKey: true)
+          event = new MouseEvent('click', shiftKey: true)
           fileInfo.currentPath.dispatchEvent(event)
           expect(atom.clipboard.read()).toBe 'sample.txt'
 


### PR DESCRIPTION
Implement ctrl/cmd click -> copy relative path as discussed in [this issue](https://github.com/atom/status-bar/issues/104).

I've added the most obvious test, but let me know if there are others you'd like me to take a pass at..

Please also let me know if I've missed any subtle issues!

This is my first:
- atom contribution
- coffeescript
- atom spec

so I'd love to learn :)