### PR TITLE
Make updating info faster for multi-cursor edits

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -29,7 +29,8 @@ class CursorPositionView extends HTMLElement
 
   subscribeToActiveTextEditor: ->
     @cursorSubscription?.dispose()
-    @cursorSubscription = @getActiveTextEditor()?.onDidChangeCursorPosition =>
+    @cursorSubscription = @getActiveTextEditor()?.onDidChangeCursorPosition ({cursor}) =>
+      return unless cursor is @getActiveTextEditor().getLastCursor()
       @updatePosition()
     @updatePosition()
 

--- a/lib/selection-count-view.coffee
+++ b/lib/selection-count-view.coffee
@@ -25,7 +25,8 @@ class SelectionCountView extends HTMLElement
 
   subscribeToActiveTextEditor: ->
     @selectionSubscription?.dispose()
-    @selectionSubscription = @getActiveTextEditor()?.onDidChangeSelectionRange =>
+    @selectionSubscription = @getActiveTextEditor()?.onDidChangeSelectionRange ({selection}) =>
+      return unless selection is @getActiveTextEditor().getLastSelection()
       @updateCount()
     @updateCount()
 


### PR DESCRIPTION
With this PR, we take advantage of the fact that the information we present in status-bar is only based on the last cursor and selection. This means we can ignore most of the selection/cursor change events and only update the UI when the last event arrives.

#### Before

![screen shot 2016-02-16 at 12 10 47](https://cloud.githubusercontent.com/assets/482957/13074721/bcc5ed1e-d4a6-11e5-8b40-349da3e59800.png)

_(Total: `~ 330ms`, benchmarks performed by editing 3000 lines, inserting 5 characters)_

#### After

![screen shot 2016-02-16 at 12 10 19](https://cloud.githubusercontent.com/assets/482957/13074738/e6319a22-d4a6-11e5-990f-ecef6dd47d5f.png)

_(Total: `~ 7ms`, 47x faster :racehorse:)_

#### Some thoughts

I wondered if we had to expose richer events in `TextEditor` and avoid to perform this _last cursor/selection comparison_, but ultimately I believe it's fine to let the clients decide when to perform certain events without cluttering `TextEditor`'s public interface with events that can be synthesized pretty easily.

/cc: @nathansobo @maxbrunsfeld 