### PR TITLE
:racehorse: Defer updatePosition

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -49,13 +49,14 @@ class CursorPositionView extends HTMLElement
     atom.workspace.getActiveTextEditor()
 
   updatePosition: ->
-    if position = @getActiveTextEditor()?.getCursorBufferPosition()
-      @row = position.row + 1
-      @column = position.column + 1
-      @goToLineLink.textContent = @formatString.replace('%L', @row).replace('%C', @column)
-      @classList.remove('hide')
-    else
-      @goToLineLink.textContent = ''
-      @classList.add('hide')
+    atom.views.updateDocument () =>
+      if position = @getActiveTextEditor()?.getCursorBufferPosition()
+        @row = position.row + 1
+        @column = position.column + 1
+        @goToLineLink.textContent = @formatString.replace('%L', @row).replace('%C', @column)
+        @classList.remove('hide')
+      else
+        @goToLineLink.textContent = ''
+        @classList.add('hide')
 
 module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -54,7 +54,7 @@ class CursorPositionView extends HTMLElement
     return if @viewUpdatePending
 
     @viewUpdatePending = true
-    atom.views.updateDocument () =>
+    atom.views.updateDocument =>
       @viewUpdatePending = false
       if position = @getActiveTextEditor()?.getCursorBufferPosition()
         @row = position.row + 1

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -2,6 +2,8 @@
 
 class CursorPositionView extends HTMLElement
   initialize: ->
+    @viewUpdatePending = false
+
     @classList.add('cursor-position', 'inline-block')
     @goToLineLink = document.createElement('a')
     @goToLineLink.classList.add('inline-block')
@@ -49,7 +51,11 @@ class CursorPositionView extends HTMLElement
     atom.workspace.getActiveTextEditor()
 
   updatePosition: ->
+    return if @viewUpdatePending
+
+    @viewUpdatePending = true
     atom.views.updateDocument () =>
+      @viewUpdatePending = false
       if position = @getActiveTextEditor()?.getCursorBufferPosition()
         @row = position.row + 1
         @column = position.column + 1

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -214,16 +214,22 @@ describe "Built-in Status Bar Tiles", ->
         jasmine.attachToDOM(workspaceElement)
 
         editor.setSelectedBufferRange([[0, 0], [0, 0]])
+        atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe ''
+
         editor.setSelectedBufferRange([[0, 0], [0, 2]])
+        atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe '(1, 2)'
+
         editor.setSelectedBufferRange([[0, 0], [1, 30]])
+        atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe '(2, 60)'
 
     describe "when the active pane item does not implement getCursorBufferPosition()", ->
       it "hides the cursor position view", ->
         jasmine.attachToDOM(workspaceElement)
         atom.workspace.getActivePane().activateItem(dummyView)
+        atom.views.performDocumentUpdate()
         expect(cursorPosition).toBeHidden()
 
     describe "when the active pane item implements getTitle() but not getPath()", ->

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -36,6 +36,7 @@ describe "Built-in Status Bar Tiles", ->
           atom.workspace.open()
 
         runs ->
+          atom.views.performDocumentUpdate()
           expect(fileInfo.currentPath.textContent).toBe 'untitled'
           expect(cursorPosition.textContent).toBe '1:1'
           expect(selectionCount).toBeHidden()
@@ -205,6 +206,7 @@ describe "Built-in Status Bar Tiles", ->
       it "updates the cursor position in the status bar", ->
         jasmine.attachToDOM(workspaceElement)
         editor.setCursorScreenPosition([1, 2])
+        atom.views.performDocumentUpdate()
         expect(cursorPosition.textContent).toBe '2:3'
 
     describe "when the associated editor's selection changes", ->
@@ -261,14 +263,17 @@ describe "Built-in Status Bar Tiles", ->
       it 'respects a format string', ->
         jasmine.attachToDOM(workspaceElement)
         editor.setCursorScreenPosition([1, 2])
+        atom.views.performDocumentUpdate()
         expect(cursorPosition.textContent).toBe 'foo 2 bar 3'
 
       it 'updates when the configuration changes', ->
         jasmine.attachToDOM(workspaceElement)
         editor.setCursorScreenPosition([1, 2])
+        atom.views.performDocumentUpdate()
         expect(cursorPosition.textContent).toBe 'foo 2 bar 3'
 
         atom.config.set('status-bar.cursorPositionFormat', 'baz %C quux %L')
+        atom.views.performDocumentUpdate()
         expect(cursorPosition.textContent).toBe 'baz 3 quux 2'
 
       describe "when clicked", ->


### PR DESCRIPTION
When the text content of the cursor position view is updated, layout is invalidated. This can result in forced layout soon after, which adds time between event handler and animation frame. This can add to a sluggish feeling during arrow navigation and typing.

This is mostly not that bad, but can be a notable drag when the DOM is large.

@nathansobo: I believe that the solution here is what you suggested when we spoke a couple weeks back. I'm not sure if I did it right, but it appears to solve the problem. :) (Also cc @ssorallen)

Test Plan:

Add text to a plaintext file. Navigate with arrow keys, verify that layout is no longer forced by the cursor position update.

Before:

![screen shot 2016-04-04 at 1 53 26 pm](https://cloud.githubusercontent.com/assets/2823852/14263085/8a1c8480-fa6d-11e5-82f1-1db19760ffab.png)

After:

![screen shot 2016-04-04 at 1 50 29 pm](https://cloud.githubusercontent.com/assets/2823852/14263101/a12c69f6-fa6d-11e5-9560-8b999a79c008.png)
