### PR TITLE
Track disposable for updatePosition

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -28,6 +28,7 @@ class CursorPositionView extends HTMLElement
     @tooltip.dispose()
     @configSubscription?.dispose()
     @clickSubscription.dispose()
+    @updateSubscription?.dispose()
 
   subscribeToActiveTextEditor: ->
     @cursorSubscription?.dispose()
@@ -54,7 +55,7 @@ class CursorPositionView extends HTMLElement
     return if @viewUpdatePending
 
     @viewUpdatePending = true
-    atom.views.updateDocument =>
+    @updateSubscription = atom.views.updateDocument =>
       @viewUpdatePending = false
       if position = @getActiveTextEditor()?.getCursorBufferPosition()
         @row = position.row + 1


### PR DESCRIPTION
Within `updatePosition`, we now use `atom.views.updateDocument`. This returns a `Disposable`, which can be disposed during the destroy phase to ensure that the callback does not execute and cause DOM errors.