### PR TITLE
Fix incomplete file path copied when there is a #

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -40,7 +40,8 @@ class FileInfoView extends HTMLElement
   getActiveItemCopyText: (copyRelativePath) ->
     activeItem = @getActiveItem()
     # An item path could be a url, but we only want to copy the `path` part of it.
-    path = url.parse(activeItem?.getPath?() or '').path or activeItem?.getTitle?() or ''
+    pathObject = url.parse(activeItem?.getPath?() or '')
+    path = (pathObject.path + pathObject.hash) or activeItem?.getTitle?() or ''
 
     if copyRelativePath
       atom.project.relativize(path)

--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -41,7 +41,12 @@ class FileInfoView extends HTMLElement
     activeItem = @getActiveItem()
     # An item path could be a url, but we only want to copy the `path` part of it.
     pathObject = url.parse(activeItem?.getPath?() or '')
-    path = (pathObject.path + pathObject.hash) or activeItem?.getTitle?() or ''
+    if pathObject.path
+      path = pathObject.path
+      if pathObject.hash
+        path += pathObject.hash
+    else
+      path = activeItem?.getTitle?() or ''
 
     if copyRelativePath
       atom.project.relativize(path)

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -73,6 +73,14 @@ describe "Built-in Status Bar Tiles", ->
           fileInfo.currentPath.click()
           expect(atom.clipboard.read()).toBe fileInfo.getActiveItem().getPath()
 
+      it "does not leave out the path after hash", ->
+        waitsForPromise ->
+          atom.workspace.open('file_with_#_in_name.txt')
+
+        runs ->
+          fileInfo.currentPath.click()
+          expect(atom.clipboard.read()).toBe fileInfo.getActiveItem().getPath()
+
     describe "when buffer's path is shift-clicked", ->
       it "copies the relative path into the clipboard if available", ->
         waitsForPromise ->


### PR DESCRIPTION
Fixes #116.

Simple appending of the fragment portion ('# ...') to the copied path.
<img src='https://cloud.githubusercontent.com/assets/12193772/14465751/ad6d9ed4-0106-11e6-88a9-86097a80ac82.png' width=400/>
