### PR TITLE
Windows compatibility

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -39,8 +39,12 @@ class FileInfoView extends HTMLElement
 
   getActiveItemCopyText: (copyRelativePath) ->
     activeItem = @getActiveItem()
-    # An item path could be a url, but we only want to copy the `path` part of it.
-    path = url.parse(activeItem?.getPath?() or '').path or activeItem?.getTitle?() or ''
+    path = activeItem?.getPath?()
+    # An item path could be a url, we only want to copy the `path` part
+    if path?.indexOf('://') > 0
+      path = url.parse(path).path
+
+    return activeItem?.getTitle?() or '' if not path?
 
     if copyRelativePath
       atom.project.relativize(path)

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -1,6 +1,7 @@
 fs = require 'fs-plus'
 path = require 'path'
 os = require 'os'
+process = require 'process'
 {$} = require 'atom-space-pen-views'
 
 describe "Built-in Status Bar Tiles", ->
@@ -241,7 +242,7 @@ describe "Built-in Status Bar Tiles", ->
 
         editor.setSelectedBufferRange([[0, 0], [1, 30]])
         atom.views.performDocumentUpdate()
-        expect(selectionCount.textContent).toBe '(2, 60)'
+        expect(selectionCount.textContent).toBe "(2, #{if process.platform is 'win32' then 61 else 60})"
 
     describe "when the active pane item does not implement getCursorBufferPosition()", ->
       it "hides the cursor position view", ->
@@ -308,21 +309,23 @@ describe "Built-in Status Bar Tiles", ->
           expect(eventHandler).toHaveBeenCalled()
 
     describe 'the selection count tile', ->
+      expectedCharacters = if process.platform is 'win32' then 61 else 60
+
       beforeEach ->
         atom.config.set('status-bar.selectionCountFormat', '%L foo %C bar selected')
 
       it 'respects a format string', ->
         jasmine.attachToDOM(workspaceElement)
         editor.setSelectedBufferRange([[0, 0], [1, 30]])
-        expect(selectionCount.textContent).toBe '2 foo 60 bar selected'
+        expect(selectionCount.textContent).toBe "2 foo #{expectedCharacters} bar selected"
 
       it 'updates when the configuration changes', ->
         jasmine.attachToDOM(workspaceElement)
         editor.setSelectedBufferRange([[0, 0], [1, 30]])
-        expect(selectionCount.textContent).toBe '2 foo 60 bar selected'
+        expect(selectionCount.textContent).toBe "2 foo #{expectedCharacters} bar selected"
 
         atom.config.set('status-bar.selectionCountFormat', 'Selection: baz %C quux %L')
-        expect(selectionCount.textContent).toBe 'Selection: baz 60 quux 2'
+        expect(selectionCount.textContent).toBe "Selection: baz #{expectedCharacters} quux 2"
 
 
   describe "the git tile", ->

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -423,8 +423,7 @@ describe "Built-in Status Bar Tiles", ->
 
         repo = atom.project.getRepositories()[0].async
         originalPathText = fs.readFileSync(filePath, 'utf8')
-
-        waitsForPromise -> repo._refreshingPromise
+        waitsForPromise -> repo.refreshStatus()
 
       afterEach ->
         fs.writeFileSync(filePath, originalPathText)

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -115,7 +115,7 @@ describe "Built-in Status Bar Tiles", ->
           expect(document.querySelector('.tooltip')).not.toExist()
 
     describe "when saved buffer's path is clicked", ->
-      it "displays a tooltip containing text 'Copied:' and an absolute path", ->
+      it "displays a tooltip containing text 'Copied:' and an absolute native path", ->
         jasmine.attachToDOM(workspaceElement)
         waitsForPromise ->
           atom.workspace.open('sample.txt')
@@ -123,6 +123,24 @@ describe "Built-in Status Bar Tiles", ->
         runs ->
           fileInfo.currentPath.click()
           expect(document.querySelector('.tooltip')).toHaveText "Copied: #{fileInfo.getActiveItem().getPath()}"
+
+      it "displays a tooltip containing text 'Copied:' for an absolute Unix path", ->
+        jasmine.attachToDOM(workspaceElement)
+        dummyView.getPath = -> '/user/path/for/my/file.txt'
+        atom.workspace.getActivePane().activateItem(dummyView)
+
+        runs ->
+          fileInfo.currentPath.click()
+          expect(document.querySelector('.tooltip')).toHaveText "Copied: #{dummyView.getPath()}"
+
+      it "displays a tooltip containing text 'Copied:' for an absolute Windows path", ->
+        jasmine.attachToDOM(workspaceElement)
+        dummyView.getPath = -> 'c:\\user\\path\\for\\my\\file.txt'
+        atom.workspace.getActivePane().activateItem(dummyView)
+
+        runs ->
+          fileInfo.currentPath.click()
+          expect(document.querySelector('.tooltip')).toHaveText "Copied: #{dummyView.getPath()}"
 
     describe "when unsaved buffer's path is clicked", ->
       it "displays a tooltip containing text 'Copied: untitled", ->

--- a/spec/fixtures/git/working-dir/newfile.txt
+++ b/spec/fixtures/git/working-dir/newfile.txt
@@ -1,0 +1,1 @@
+I'm new here

--- a/spec/fixtures/git/working-dir/newfile.txt
+++ b/spec/fixtures/git/working-dir/newfile.txt
@@ -1,1 +1,0 @@
-I'm new here


### PR DESCRIPTION
This make status-bar specs pass on Windows and leaves Windows paths in-tact on copy and tooltips.