### PR TITLE
Adjust selection line count

### DIFF
--- a/lib/selection-count-view.coffee
+++ b/lib/selection-count-view.coffee
@@ -35,7 +35,9 @@ class SelectionCountView extends HTMLElement
 
   updateCount: ->
     count = @getActiveTextEditor()?.getSelectedText().length
-    lineCount = @getActiveTextEditor()?.getSelectedBufferRange().getRowCount()
+    range = @getActiveTextEditor()?.getSelectedBufferRange()
+    lineCount = range?.getRowCount()
+    lineCount -= 1 if range?.end.column is 0
     if count > 0
       @textContent = @formatString.replace('%L', lineCount).replace('%C', count)
       title = "#{_.pluralize(lineCount, 'line')}, #{_.pluralize(count, 'character')} selected"

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -327,6 +327,11 @@ describe "Built-in Status Bar Tiles", ->
         atom.config.set('status-bar.selectionCountFormat', 'Selection: baz %C quux %L')
         expect(selectionCount.textContent).toBe "Selection: baz #{expectedCharacters} quux 2"
 
+      it 'does not include the next line if the last selected character is a newline', ->
+        expectedCharactersFirstLine = if process.platform is 'win32' then 31 else 30
+        jasmine.attachToDOM(workspaceElement)
+        editor.setSelectedBufferRange([[0, 0], [1, 0]])
+        expect(selectionCount.textContent).toBe "1 foo #{expectedCharactersFirstLine} bar selected"
 
   describe "the git tile", ->
     gitView = null


### PR DESCRIPTION
Fix line count when the last selected character is a newline. Previous
behavior was to include the line following the newline character
in the count.
