### PR TITLE
Add option to use zero-indexed cursor position

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -11,6 +11,7 @@ class CursorPositionView extends HTMLElement
     @appendChild(@goToLineLink)
 
     @formatString = atom.config.get('status-bar.cursorPositionFormat') ? '%L:%C'
+    @columnIndex = if atom.config.get("status-bar.zeroIndexedColumns") then 0 else 1
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) =>
       @subscribeToActiveTextEditor()
 
@@ -42,6 +43,9 @@ class CursorPositionView extends HTMLElement
     @configSubscription = atom.config.observe 'status-bar.cursorPositionFormat', (value) =>
       @formatString = value ? '%L:%C'
       @updatePosition()
+    @configSubscription = atom.config.observe 'status-bar.zeroIndexedColumns', (value) =>
+      @columnIndex = if value then 0 else 1
+      @updatePosition()
 
   handleClick: ->
     clickHandler = => atom.commands.dispatch(atom.views.getView(@getActiveTextEditor()), 'go-to-line:toggle')
@@ -59,7 +63,7 @@ class CursorPositionView extends HTMLElement
       @viewUpdatePending = false
       if position = @getActiveTextEditor()?.getCursorBufferPosition()
         @row = position.row + 1
-        @column = position.column + 1
+        @column = position.column + @columnIndex
         @goToLineLink.textContent = @formatString.replace('%L', @row).replace('%C', @column)
         @classList.remove('hide')
       else

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
       "type": "string",
       "default": "(%L, %C)",
       "description": "Format for the selection count status bar element, where %L is the line count and %C is the character count"
+    },
+    "zeroIndexedColumns": {
+      "type": "boolean",
+      "default": false,
+      "description": "Horizontal cursor position starts at 0 if checked, 1 otherwise"
     }
   },
   "devDependencies": {

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -284,6 +284,7 @@ describe "Built-in Status Bar Tiles", ->
     describe 'the cursor position tile', ->
       beforeEach ->
         atom.config.set('status-bar.cursorPositionFormat', 'foo %L bar %C')
+        atom.config.set('status-bar.zeroIndexedColumns', false)
 
       it 'respects a format string', ->
         jasmine.attachToDOM(workspaceElement)
@@ -300,6 +301,16 @@ describe "Built-in Status Bar Tiles", ->
         atom.config.set('status-bar.cursorPositionFormat', 'baz %C quux %L')
         atom.views.performDocumentUpdate()
         expect(cursorPosition.textContent).toBe 'baz 3 quux 2'
+
+      it 'starts with column 0 or 1 according to the configuration', ->
+        jasmine.attachToDOM(workspaceElement)
+        editor.setCursorScreenPosition([1, 2])
+        atom.views.performDocumentUpdate()
+        expect(cursorPosition.textContent).toBe 'foo 2 bar 3'
+
+        atom.config.set('status-bar.zeroIndexedColumns', true)
+        atom.views.performDocumentUpdate()
+        expect(cursorPosition.textContent).toBe 'foo 2 bar 2'
 
       describe "when clicked", ->
         it "triggers the go-to-line toggle event", ->


### PR DESCRIPTION
This update answers the #144 issue.
New checkbox in package settings:
- if checked, cursor starts at position 0
- if unchecked, cursor starts at position 1

[edit] Default option value is "unchecked", so columns are 1-indexed in line with existing behavior.
