### PR TITLE
Add package setting to toggle full-width status-bar

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable, Emitter} = require 'atom'
 Grim = require 'grim'
 StatusBarView = require './status-bar-view'
 FileInfoView = require './file-info-view'
@@ -7,9 +8,15 @@ GitView = require './git-view'
 
 module.exports =
   activate: ->
+    @emitters = new Emitter()
+    @subscriptions = new CompositeDisposable()
+
     @statusBar = new StatusBarView()
     @statusBar.initialize()
-    @statusBarPanel = atom.workspace.addFooterPanel(item: @statusBar, priority: 0)
+    @attachStatusBar()
+
+    @subscriptions.add atom.config.onDidChange 'status-bar.fullWidth', =>
+      @attachStatusBar()
 
     atom.commands.add 'atom-workspace', 'status-bar:toggle', =>
       if @statusBarPanel.isVisible()
@@ -59,6 +66,12 @@ module.exports =
     @statusBar?.destroy()
     @statusBar = null
 
+    @subscriptions?.dispose()
+    @subscriptions = null
+
+    @emitters?.dispose()
+    @emitters = null
+
     delete atom.__workspaceView.statusBar if atom.__workspaceView?
 
   provideStatusBar: ->
@@ -67,7 +80,16 @@ module.exports =
     getLeftTiles: @statusBar.getLeftTiles.bind(@statusBar)
     getRightTiles: @statusBar.getRightTiles.bind(@statusBar)
 
-  # Depreciated
+  attachStatusBar: ->
+    @statusBarPanel.destroy() if @statusBarPanel?
+
+    panelArgs = item: @statusBar, priority: 0
+    if atom.config.get('status-bar.fullWidth')
+      @statusBarPanel = atom.workspace.addFooterPanel panelArgs
+    else
+      @statusBarPanel = atom.workspace.addBottomPanel panelArgs
+
+  # Deprecated
   #
   # Wrap deprecation calls on the methods returned rather than
   # Services API method which would be registered and trigger

--- a/package.json
+++ b/package.json
@@ -23,12 +23,21 @@
     }
   },
   "configSchema": {
+    "fullWidth": {
+      "order": 1,
+      "type": "boolean",
+      "default": true,
+      "title": "Full-width",
+      "description": "Fit the status-bar to the window's full-width"
+    },
     "cursorPositionFormat": {
+      "order": 2,
       "type": "string",
       "default": "%L:%C",
       "description": "Format for the cursor position status bar element, where %L is the line number and %C is the column number"
     },
     "selectionCountFormat": {
+      "order": 2,
       "type": "string",
       "default": "(%L, %C)",
       "description": "Format for the selection count status bar element, where %L is the line count and %C is the character count"

--- a/spec/status-bar-spec.coffee
+++ b/spec/status-bar-spec.coffee
@@ -1,5 +1,5 @@
 describe "Status Bar package", ->
-  [editor, statusBar, statusBarService, workspaceElement] = []
+  [editor, statusBar, statusBarService, workspaceElement, mainModule] = []
 
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
@@ -8,6 +8,7 @@ describe "Status Bar package", ->
       atom.packages.activatePackage('status-bar').then (pack) ->
         statusBar = workspaceElement.querySelector("status-bar")
         statusBarService = pack.mainModule.provideStatusBar()
+        {mainModule} = pack
 
   describe "@activate()", ->
     it "appends only one status bar", ->
@@ -29,6 +30,31 @@ describe "Status Bar package", ->
       expect(workspaceElement.querySelector('status-bar').parentNode).not.toBeVisible()
       atom.commands.dispatch(workspaceElement, 'status-bar:toggle')
       expect(workspaceElement.querySelector('status-bar').parentNode).toBeVisible()
+
+  describe "full-width setting", ->
+    [containers] = []
+
+    beforeEach ->
+      containers = atom.workspace.panelContainers
+      jasmine.attachToDOM(workspaceElement)
+
+      waitsForPromise ->
+        atom.workspace.open('sample.js')
+
+    it "expects the setting to be enabled by default", ->
+      expect(atom.config.get('status-bar.fullWidth')).toBeTruthy()
+      expect(containers.footer.panels).toContain(mainModule.statusBarPanel)
+
+    describe "when setting is changed", ->
+      it "fits status bar to editor's width", ->
+        atom.config.set('status-bar.fullWidth', false)
+        expect(containers.bottom.panels).toContain(mainModule.statusBarPanel)
+        expect(containers.footer.panels).not.toContain(mainModule.statusBarPanel)
+
+      it "restores the status-bar location when re-enabling setting", ->
+        atom.config.set('status-bar.fullWidth', true)
+        expect(containers.footer.panels).toContain(mainModule.statusBarPanel)
+        expect(containers.bottom.panels).not.toContain(mainModule.statusBarPanel)
 
   describe "the 'status-bar' service", ->
     it "allows tiles to be added, removed, and retrieved", ->


### PR DESCRIPTION
I have writer's block, so I'll just echo @simurai's words, [because he put it best](https://github.com/atom/status-bar/issues/91#issuecomment-145193638):

> But somehow it feels wrong. I think the reason is because the status-bar changes based on the active editor and should somewhat stay connected to it. Full-width at the bottom it feels like it's something more global and less related to the active editor.

I agree wholeheartedly, and some other users might too. Artistic rationale aside, stubborn and change-resilient users like me would appreciate having a setting to restore the status-bar's old appearance:

<img src="https://cloud.githubusercontent.com/assets/2346707/15849014/93ebc398-2cd3-11e6-919d-082c79b13954.png" width="333" alt="Figure 1" />

If it needs to be said, the setting's default value is to use the full-width status bar:

<img src="https://cloud.githubusercontent.com/assets/2346707/15849032/ac4b3996-2cd3-11e6-80b0-a223b4384d9b.png" width="333" alt="Figure 2" />

This is how the option appears in the package's settings:

<img src="https://cloud.githubusercontent.com/assets/2346707/15849065/e3c23e10-2cd3-11e6-821b-705518cb13ec.png" width="385" alt="Figure 3" />