### PR TITLE
Fix exception when changing active pane item to a non editor

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -32,8 +32,9 @@ class CursorPositionView extends HTMLElement
 
   subscribeToActiveTextEditor: ->
     @cursorSubscription?.dispose()
-    @cursorSubscription = @getActiveTextEditor()?.onDidChangeCursorPosition ({cursor}) =>
-      return unless cursor is @getActiveTextEditor().getLastCursor()
+    activeEditor = @getActiveTextEditor()
+    @cursorSubscription = activeEditor?.onDidChangeCursorPosition ({cursor}) =>
+      return unless cursor is activeEditor.getLastCursor()
       @updatePosition()
     @updatePosition()
 

--- a/lib/selection-count-view.coffee
+++ b/lib/selection-count-view.coffee
@@ -25,8 +25,9 @@ class SelectionCountView extends HTMLElement
 
   subscribeToActiveTextEditor: ->
     @selectionSubscription?.dispose()
-    @selectionSubscription = @getActiveTextEditor()?.onDidChangeSelectionRange ({selection}) =>
-      return unless selection is @getActiveTextEditor().getLastSelection()
+    activeEditor = @getActiveTextEditor()
+    @selectionSubscription = activeEditor?.onDidChangeSelectionRange ({selection}) =>
+      return unless selection is activeEditor.getLastSelection()
       @updateCount()
     @updateCount()
 

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -228,6 +228,15 @@ describe "Built-in Status Bar Tiles", ->
         atom.views.performDocumentUpdate()
         expect(cursorPosition.textContent).toBe '2:3'
 
+      it "does not throw an exception if the cursor is moved as the result of the active pane item changing to a non-editor (regression)", ->
+        # FIXME: Restructure this spec to build a new workspace for each test so we can subscribe to this event before
+        # activating this package. Then we won't need to use these internals. I don't have time right now.
+        atom.workspace.paneContainer.emitter.preempt('did-change-active-pane-item', -> editor.setCursorScreenPosition([1, 2]))
+        atom.workspace.getActivePane().activateItem(document.createElement('div'))
+        expect(editor.getCursorScreenPosition()).toEqual([1, 2])
+        atom.views.performDocumentUpdate()
+        expect(cursorPosition).toBeHidden()
+
     describe "when the associated editor's selection changes", ->
       it "updates the selection count in the status bar", ->
         jasmine.attachToDOM(workspaceElement)
@@ -243,6 +252,15 @@ describe "Built-in Status Bar Tiles", ->
         editor.setSelectedBufferRange([[0, 0], [1, 30]])
         atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe "(2, 60)"
+
+      it "does not throw an exception if the cursor is moved as the result of the active pane item changing to a non-editor (regression)", ->
+        # FIXME: Restructure this spec to build a new workspace for each test so we can subscribe to this event before
+        # activating this package. Then we won't need to use these internals. I don't have time right now.
+        atom.workspace.paneContainer.emitter.preempt('did-change-active-pane-item', -> editor.setSelectedBufferRange([[1, 2], [1, 3]]))
+        atom.workspace.getActivePane().activateItem(document.createElement('div'))
+        expect(editor.getSelectedBufferRange()).toEqual([[1, 2], [1, 3]])
+        atom.views.performDocumentUpdate()
+        expect(selectionCount).toBeHidden()
 
     describe "when the active pane item does not implement getCursorBufferPosition()", ->
       it "hides the cursor position view", ->


### PR DESCRIPTION
When the auto-save package is enabled and the whitespace package is set to modify whitespace on the current line, the cursor position can change synchronously as the result of changing the active pane item. Previously, if we changed to a non-editor active pane item, the change handlers in the status bar tiles would still assume an editor was active and throw an exception.

This PR changes our handlers to always retrieve the last cursor from the editor we actually subscribed to.

Had to resort to some unsavory tactics to test this weird interaction, but I don't have time to restructure these tests to be more modular, which would be the only other solution.