### PR TITLE
Tildify path in status bar

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -1,5 +1,6 @@
 {Disposable} = require 'atom'
 url = require 'url'
+fs = require 'fs-plus'
 
 class FileInfoView extends HTMLElement
   initialize: ->
@@ -94,7 +95,7 @@ class FileInfoView extends HTMLElement
 
   updatePathText: ->
     if path = @getActiveItem()?.getPath?()
-      @currentPath.textContent = atom.project.relativize(path)
+      @currentPath.textContent = fs.tildify(atom.project.relativize(path))
     else if title = @getActiveItem()?.getTitle?()
       @currentPath.textContent = title
     else

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "atom": "*"
   },
   "dependencies": {
-    "fs-plus": "^2.0.0",
+    "fs-plus": "^2.9.3",
     "grim": "^1.0.0",
     "underscore-plus": "^1.0.0"
   },


### PR DESCRIPTION
This will use ~/ for the path to the home directory to be consistent with the path displayed in the title (https://github.com/atom/atom/pull/12753)

Unfortunately one test fails [here](https://github.com/atom/status-bar/blob/master/spec/built-in-tiles-spec.coffee#L61) because `fs.tildify` normalizes the path and therefor removes the double slashes. How should this be handled?