### PR TITLE
Add service for disabling Git info tile

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -36,13 +36,13 @@ module.exports =
     @selectionCount.initialize()
     @statusBar.addLeftTile(item: @selectionCount, priority: 2)
 
-    @git = new GitView()
-    @git.initialize()
-    @statusBar.addRightTile(item: @git, priority: 0)
+    @gitInfo = new GitView()
+    @gitInfo.initialize()
+    @gitInfoTile = @statusBar.addRightTile(item: @gitInfo, priority: 0)
 
   deactivate: ->
-    @git?.destroy()
-    @git = null
+    @gitInfo?.destroy()
+    @gitInfo = null
 
     @fileInfo?.destroy()
     @fileInfo = null
@@ -66,6 +66,10 @@ module.exports =
     addRightTile: @statusBar.addRightTile.bind(@statusBar)
     getLeftTiles: @statusBar.getLeftTiles.bind(@statusBar)
     getRightTiles: @statusBar.getRightTiles.bind(@statusBar)
+    disableGitInfoTile: @disableGitInfoTile.bind(this)
+
+  disableGitInfoTile: ->
+    @gitInfoTile.destroy()
 
   # Depreciated
   #

--- a/spec/status-bar-spec.coffee
+++ b/spec/status-bar-spec.coffee
@@ -47,3 +47,11 @@ describe "Status Bar package", ->
       tile.destroy()
       expect(statusBar).not.toContain(dummyView)
       expect(statusBarService.getRightTiles()).not.toContain(tile)
+
+    it "allows the git info tile to be disabled", ->
+      getGitInfoTile = ->
+        statusBar.getRightTiles().find((tile) -> tile.item.matches('.git-view'))
+
+      expect(getGitInfoTile()).not.toBeUndefined()
+      statusBarService.disableGitInfoTile()
+      expect(getGitInfoTile()).toBeUndefined()


### PR DESCRIPTION
This will allow other packages to implement this feature.

🍐 ed with @damieng 

/cc @kuychaco 