### PR TITLE
Remove custom element registration during startup

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -1,14 +1,16 @@
 {Disposable} = require 'atom'
 
-class CursorPositionView extends HTMLElement
-  initialize: ->
+module.exports =
+class CursorPositionView
+  constructor: ->
     @viewUpdatePending = false
 
-    @classList.add('cursor-position', 'inline-block')
+    @element = document.createElement('status-bar-cursor')
+    @element.classList.add('cursor-position', 'inline-block')
     @goToLineLink = document.createElement('a')
     @goToLineLink.classList.add('inline-block')
     @goToLineLink.href = '#'
-    @appendChild(@goToLineLink)
+    @element.appendChild(@goToLineLink)
 
     @formatString = atom.config.get('status-bar.cursorPositionFormat') ? '%L:%C'
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) =>
@@ -17,8 +19,7 @@ class CursorPositionView extends HTMLElement
     @subscribeToConfig()
     @subscribeToActiveTextEditor()
 
-    @tooltip = atom.tooltips.add(this, title: ->
-      "Line #{@row}, Column #{@column}")
+    @tooltip = atom.tooltips.add(@element, title: => "Line #{@row}, Column #{@column}")
 
     @handleClick()
 
@@ -46,8 +47,8 @@ class CursorPositionView extends HTMLElement
 
   handleClick: ->
     clickHandler = => atom.commands.dispatch(atom.views.getView(@getActiveTextEditor()), 'go-to-line:toggle')
-    @addEventListener('click', clickHandler)
-    @clickSubscription = new Disposable => @removeEventListener('click', clickHandler)
+    @element.addEventListener('click', clickHandler)
+    @clickSubscription = new Disposable => @element.removeEventListener('click', clickHandler)
 
   getActiveTextEditor: ->
     atom.workspace.getActiveTextEditor()
@@ -62,9 +63,7 @@ class CursorPositionView extends HTMLElement
         @row = position.row + 1
         @column = position.column + 1
         @goToLineLink.textContent = @formatString.replace('%L', @row).replace('%C', @column)
-        @classList.remove('hide')
+        @element.classList.remove('hide')
       else
         @goToLineLink.textContent = ''
-        @classList.add('hide')
-
-module.exports = document.registerElement('status-bar-cursor', prototype: CursorPositionView.prototype, extends: 'div')
+        @element.classList.add('hide')

--- a/lib/git-view.coffee
+++ b/lib/git-view.coffee
@@ -1,9 +1,11 @@
 _ = require "underscore-plus"
 {CompositeDisposable, GitRepositoryAsync} = require "atom"
 
-class GitView extends HTMLElement
-  initialize: ->
-    @classList.add('git-view')
+module.exports =
+class GitView
+  constructor: ->
+    @element = document.createElement('status-bar-git')
+    @element.classList.add('git-view')
 
     @createBranchArea()
     @createCommitsArea()
@@ -19,7 +21,8 @@ class GitView extends HTMLElement
   createBranchArea: ->
     @branchArea = document.createElement('div')
     @branchArea.classList.add('git-branch', 'inline-block')
-    @appendChild(@branchArea)
+    @element.appendChild(@branchArea)
+    @element.branchArea = @branchArea
 
     branchIcon = document.createElement('span')
     branchIcon.classList.add('icon', 'icon-git-branch')
@@ -28,11 +31,12 @@ class GitView extends HTMLElement
     @branchLabel = document.createElement('span')
     @branchLabel.classList.add('branch-label')
     @branchArea.appendChild(@branchLabel)
+    @element.branchLabel = @branchLabel
 
   createCommitsArea: ->
     @commitsArea = document.createElement('div')
     @commitsArea.classList.add('git-commits', 'inline-block')
-    @appendChild(@commitsArea)
+    @element.appendChild(@commitsArea)
 
     @commitsAhead = document.createElement('span')
     @commitsAhead.classList.add('icon', 'icon-arrow-up', 'commits-ahead-label')
@@ -45,11 +49,12 @@ class GitView extends HTMLElement
   createStatusArea: ->
     @gitStatus = document.createElement('div')
     @gitStatus.classList.add('git-status', 'inline-block')
-    @appendChild(@gitStatus)
+    @element.appendChild(@gitStatus)
 
     @gitStatusIcon = document.createElement('span')
     @gitStatusIcon.classList.add('icon')
     @gitStatus.appendChild(@gitStatusIcon)
+    @element.gitStatusIcon = @gitStatusIcon
 
   subscribeToActiveItem: ->
     activeItem = @getActiveItem()
@@ -215,5 +220,3 @@ class GitView extends HTMLElement
         hideStatus()
     else
       hideStatus()
-
-module.exports = document.registerElement('status-bar-git', prototype: GitView.prototype, extends: 'div')

--- a/lib/launch-mode-view.coffee
+++ b/lib/launch-mode-view.coffee
@@ -1,14 +1,14 @@
-class LaunchModeView extends HTMLElement
-  initialize: ({safeMode, devMode}={}) ->
-    @classList.add('inline-block', 'icon', 'icon-color-mode')
+module.exports =
+class LaunchModeView
+  constructor: ({safeMode, devMode}={}) ->
+    @element = document.createElement('status-bar-launch-mode')
+    @element.classList.add('inline-block', 'icon', 'icon-color-mode')
     if devMode
-      @classList.add('text-error')
-      @tooltipDisposable = atom.tooltips.add(this, title: 'This window is in dev mode')
+      @element.classList.add('text-error')
+      @tooltipDisposable = atom.tooltips.add(@element, title: 'This window is in dev mode')
     else if safeMode
-      @classList.add('text-success')
-      @tooltipDisposable = atom.tooltips.add(this, title: 'This window is in safe mode')
+      @element.classList.add('text-success')
+      @tooltipDisposable = atom.tooltips.add(@element, title: 'This window is in safe mode')
 
   detachedCallback: ->
     @tooltipDisposable?.dispose()
-
-module.exports = document.registerElement('status-bar-launch-mode', prototype: LaunchModeView.prototype, extends: 'span')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -38,8 +38,7 @@ module.exports =
       @statusBar.addLeftTile(item: launchModeView, priority: -1)
 
     @fileInfo = new FileInfoView()
-    @fileInfo.initialize()
-    @statusBar.addLeftTile(item: @fileInfo, priority: 0)
+    @statusBar.addLeftTile(item: @fileInfo.element, priority: 0)
 
     @cursorPosition = new CursorPositionView()
     @statusBar.addLeftTile(item: @cursorPosition.element, priority: 1)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,6 +5,7 @@ FileInfoView = require './file-info-view'
 CursorPositionView = require './cursor-position-view'
 SelectionCountView = require './selection-count-view'
 GitView = require './git-view'
+LaunchModeView = require './launch-mode-view'
 
 module.exports =
   activate: ->
@@ -32,10 +33,8 @@ module.exports =
 
     {safeMode, devMode} = atom.getLoadSettings()
     if safeMode or devMode
-      LaunchModeView = require './launch-mode-view'
-      launchModeView = new LaunchModeView()
-      launchModeView.initialize({safeMode, devMode})
-      @statusBar.addLeftTile(item: launchModeView, priority: -1)
+      launchModeView = new LaunchModeView({safeMode, devMode})
+      @statusBar.addLeftTile(item: launchModeView.element, priority: -1)
 
     @fileInfo = new FileInfoView()
     @statusBar.addLeftTile(item: @fileInfo.element, priority: 0)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,7 +13,6 @@ module.exports =
     @subscriptions = new CompositeDisposable()
 
     @statusBar = new StatusBarView()
-    @statusBar.initialize()
     @attachStatusBar()
 
     @subscriptions.add atom.config.onDidChange 'status-bar.fullWidth', =>
@@ -94,7 +93,7 @@ module.exports =
   attachStatusBar: ->
     @statusBarPanel.destroy() if @statusBarPanel?
 
-    panelArgs = item: @statusBar, priority: 0
+    panelArgs = {item: @statusBar, priority: 0}
     if atom.config.get('status-bar.fullWidth')
       @statusBarPanel = atom.workspace.addFooterPanel panelArgs
     else

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -46,8 +46,7 @@ module.exports =
     @statusBar.addLeftTile(item: @selectionCount.element, priority: 2)
 
     @gitInfo = new GitView()
-    @gitInfo.initialize()
-    @gitInfoTile = @statusBar.addRightTile(item: @gitInfo, priority: 0)
+    @gitInfoTile = @statusBar.addRightTile(item: @gitInfo.element, priority: 0)
 
   deactivate: ->
     @statusBarVisibilitySubscription?.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -44,8 +44,7 @@ module.exports =
     @statusBar.addLeftTile(item: @cursorPosition.element, priority: 1)
 
     @selectionCount = new SelectionCountView()
-    @selectionCount.initialize()
-    @statusBar.addLeftTile(item: @selectionCount, priority: 2)
+    @statusBar.addLeftTile(item: @selectionCount.element, priority: 2)
 
     @gitInfo = new GitView()
     @gitInfo.initialize()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -42,8 +42,7 @@ module.exports =
     @statusBar.addLeftTile(item: @fileInfo, priority: 0)
 
     @cursorPosition = new CursorPositionView()
-    @cursorPosition.initialize()
-    @statusBar.addLeftTile(item: @cursorPosition, priority: 1)
+    @statusBar.addLeftTile(item: @cursorPosition.element, priority: 1)
 
     @selectionCount = new SelectionCountView()
     @selectionCount.initialize()
@@ -56,7 +55,7 @@ module.exports =
   deactivate: ->
     @statusBarVisibilitySubscription?.dispose()
     @statusBarVisibilitySubscription = null
-    
+
     @gitInfo?.destroy()
     @gitInfo = null
 

--- a/lib/selection-count-view.coffee
+++ b/lib/selection-count-view.coffee
@@ -1,9 +1,10 @@
 _ = require 'underscore-plus'
 
-class SelectionCountView extends HTMLElement
-
-  initialize: ->
-    @classList.add('selection-count', 'inline-block')
+module.exports =
+class SelectionCountView
+  constructor: ->
+    @element = document.createElement('status-bar-selection')
+    @element.classList.add('selection-count', 'inline-block')
 
     @formatString = atom.config.get('status-bar.selectionCountFormat') ? '(%L, %C)'
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
@@ -40,11 +41,9 @@ class SelectionCountView extends HTMLElement
     lineCount = range?.getRowCount()
     lineCount -= 1 if range?.end.column is 0
     if count > 0
-      @textContent = @formatString.replace('%L', lineCount).replace('%C', count)
+      @element.textContent = @formatString.replace('%L', lineCount).replace('%C', count)
       title = "#{_.pluralize(lineCount, 'line')}, #{_.pluralize(count, 'character')} selected"
       @toolTipDisposable?.dispose()
-      @toolTipDisposable = atom.tooltips.add this, title: title
+      @toolTipDisposable = atom.tooltips.add @element, title: title
     else
-      @textContent = ''
-
-module.exports = document.registerElement('status-bar-selection', prototype: SelectionCountView.prototype, extends: 'div')
+      @element.textContent = ''

--- a/lib/status-bar-view.coffee
+++ b/lib/status-bar-view.coffee
@@ -1,13 +1,15 @@
 {Disposable} = require 'atom'
 Tile = require './tile'
 
-class StatusBarView extends HTMLElement
-  createdCallback: ->
-    @classList.add('status-bar')
+module.exports =
+class StatusBarView
+  constructor: ->
+    @element = document.createElement('status-bar')
+    @element.classList.add('status-bar')
 
     flexboxHackElement = document.createElement('div')
     flexboxHackElement.classList.add('flexbox-repaint-hack')
-    @appendChild(flexboxHackElement)
+    @element.appendChild(flexboxHackElement)
 
     @leftPanel = document.createElement('div')
     @leftPanel.classList.add('status-bar-left')
@@ -20,7 +22,11 @@ class StatusBarView extends HTMLElement
     @leftTiles = []
     @rightTiles = []
 
-  initialize: ->
+    @element.getLeftTiles = @getLeftTiles.bind(this)
+    @element.getRightTiles = @getRightTiles.bind(this)
+    @element.addLeftTile = @addLeftTile.bind(this)
+    @element.addRightTile = @addRightTile.bind(this)
+
     @bufferSubscriptions = []
 
     @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
@@ -28,15 +34,14 @@ class StatusBarView extends HTMLElement
       @storeActiveBuffer()
       @subscribeAllToBuffer()
 
-      @dispatchEvent(new CustomEvent('active-buffer-changed', bubbles: true))
+      @element.dispatchEvent(new CustomEvent('active-buffer-changed', bubbles: true))
 
     @storeActiveBuffer()
-    this
 
   destroy: ->
     @activeItemSubscription.dispose()
     @unsubscribeAllFromBuffer()
-    @remove()
+    @element.remove()
 
   addLeftTile: (options) ->
     newItem = options.item
@@ -98,5 +103,3 @@ class StatusBarView extends HTMLElement
     return unless @buffer
     for [event, callback] in @bufferSubscriptions
       @buffer.off(event, callback)
-
-module.exports = document.registerElement('status-bar', prototype: StatusBarView.prototype)

--- a/spec/status-bar-view-spec.coffee
+++ b/spec/status-bar-view-spec.coffee
@@ -1,13 +1,13 @@
-StatusBarElement = require '../lib/status-bar-view'
+StatusBarView = require '../lib/status-bar-view'
 
-describe "StatusBarElement", ->
-  statusBarElement = null
+describe "StatusBarView", ->
+  statusBarView = null
 
   class TestItem
     constructor: (@id) ->
 
   beforeEach ->
-    statusBarElement = new StatusBarElement().initialize()
+    statusBarView = new StatusBarView()
 
     atom.views.addViewProvider TestItem, (model) ->
       element = document.createElement("item-view")
@@ -20,11 +20,11 @@ describe "StatusBarElement", ->
       testItem2 = new TestItem(2)
       testItem3 = new TestItem(3)
 
-      tile1 = statusBarElement.addLeftTile(item: testItem1, priority: 10)
-      tile2 = statusBarElement.addLeftTile(item: testItem2, priority: 30)
-      tile3 = statusBarElement.addLeftTile(item: testItem3, priority: 20)
+      tile1 = statusBarView.addLeftTile(item: testItem1, priority: 10)
+      tile2 = statusBarView.addLeftTile(item: testItem2, priority: 30)
+      tile3 = statusBarView.addLeftTile(item: testItem3, priority: 20)
 
-      {leftPanel} = statusBarElement
+      {leftPanel} = statusBarView
 
       expect(leftPanel.children[0].nodeName).toBe("ITEM-VIEW")
       expect(leftPanel.children[1].nodeName).toBe("ITEM-VIEW")
@@ -34,27 +34,27 @@ describe "StatusBarElement", ->
       expect(leftPanel.children[1].model).toBe(testItem3)
       expect(leftPanel.children[2].model).toBe(testItem2)
 
-      expect(statusBarElement.getLeftTiles()).toEqual([tile1, tile3, tile2])
+      expect(statusBarView.getLeftTiles()).toEqual([tile1, tile3, tile2])
       expect(tile1.getPriority()).toBe(10)
       expect(tile1.getItem()).toBe(testItem1)
 
     it "allows the view to be removed", ->
       testItem = new TestItem(1)
-      tile = statusBarElement.addLeftTile(item: testItem, priority: 10)
+      tile = statusBarView.addLeftTile(item: testItem, priority: 10)
       tile.destroy()
-      expect(statusBarElement.leftPanel.children.length).toBe(0)
+      expect(statusBarView.leftPanel.children.length).toBe(0)
 
-      statusBarElement.addLeftTile(item: testItem, priority: 9)
+      statusBarView.addLeftTile(item: testItem, priority: 9)
 
     describe "when no priority is given", ->
       it "appends the item", ->
         testItem1 = new TestItem(1)
         testItem2 = new TestItem(2)
 
-        statusBarElement.addLeftTile(item: testItem1, priority: 1000)
-        statusBarElement.addLeftTile(item: testItem2)
+        statusBarView.addLeftTile(item: testItem1, priority: 1000)
+        statusBarView.addLeftTile(item: testItem2)
 
-        {leftPanel} = statusBarElement
+        {leftPanel} = statusBarView
         expect(leftPanel.children[0].model).toBe(testItem1)
         expect(leftPanel.children[1].model).toBe(testItem2)
 
@@ -64,11 +64,11 @@ describe "StatusBarElement", ->
       testItem2 = new TestItem(2)
       testItem3 = new TestItem(3)
 
-      tile1 = statusBarElement.addRightTile(item: testItem1, priority: 10)
-      tile2 = statusBarElement.addRightTile(item: testItem2, priority: 30)
-      tile3 = statusBarElement.addRightTile(item: testItem3, priority: 20)
+      tile1 = statusBarView.addRightTile(item: testItem1, priority: 10)
+      tile2 = statusBarView.addRightTile(item: testItem2, priority: 30)
+      tile3 = statusBarView.addRightTile(item: testItem3, priority: 20)
 
-      {rightPanel} = statusBarElement
+      {rightPanel} = statusBarView
 
       expect(rightPanel.children[0].nodeName).toBe("ITEM-VIEW")
       expect(rightPanel.children[1].nodeName).toBe("ITEM-VIEW")
@@ -78,26 +78,26 @@ describe "StatusBarElement", ->
       expect(rightPanel.children[1].model).toBe(testItem3)
       expect(rightPanel.children[2].model).toBe(testItem1)
 
-      expect(statusBarElement.getRightTiles()).toEqual([tile2, tile3, tile1])
+      expect(statusBarView.getRightTiles()).toEqual([tile2, tile3, tile1])
       expect(tile1.getPriority()).toBe(10)
       expect(tile1.getItem()).toBe(testItem1)
 
     it "allows the view to be removed", ->
       testItem = new TestItem(1)
-      disposable = statusBarElement.addRightTile(item: testItem, priority: 10)
+      disposable = statusBarView.addRightTile(item: testItem, priority: 10)
       disposable.destroy()
-      expect(statusBarElement.rightPanel.children.length).toBe(0)
+      expect(statusBarView.rightPanel.children.length).toBe(0)
 
-      statusBarElement.addRightTile(item: testItem, priority: 11)
+      statusBarView.addRightTile(item: testItem, priority: 11)
 
     describe "when no priority is given", ->
       it "prepends the item", ->
         testItem1 = new TestItem(1, priority: 1000)
         testItem2 = new TestItem(2)
 
-        statusBarElement.addRightTile(item: testItem1, priority: 1000)
-        statusBarElement.addRightTile(item: testItem2)
+        statusBarView.addRightTile(item: testItem1, priority: 1000)
+        statusBarView.addRightTile(item: testItem2)
 
-        {rightPanel} = statusBarElement
+        {rightPanel} = statusBarView
         expect(rightPanel.children[0].model).toBe(testItem2)
         expect(rightPanel.children[1].model).toBe(testItem1)


### PR DESCRIPTION
This pull request stops registering custom elements during startup by using simple javascript objects that internally manage a DOM element.