### PR TITLE
Do not attempt to tildify undefined results

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -108,7 +108,8 @@ class FileInfoView
 
   updatePathText: ->
     if path = @getActiveItem()?.getPath?()
-      @currentPath.textContent = fs.tildify(atom.project.relativize(path))
+      relativized = atom.project.relativize(path)
+      @currentPath.textContent = if relativized? then fs.tildify(relativized) else path
     else if title = @getActiveItem()?.getTitle?()
       @currentPath.textContent = title
     else


### PR DESCRIPTION
Not sure why we end up getting undefined back from atom.project.relativize for some people and not others but this will prevent undefined and null going off to fs.tildify where they'll blow up.  

Fixes #184 