### PR TITLE
Optimize performing updates on cursor position and selection position views

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -34,16 +34,15 @@ class CursorPositionView
   subscribeToActiveTextEditor: ->
     @cursorSubscription?.dispose()
     activeEditor = @getActiveTextEditor()
-    @cursorSubscription = activeEditor?.onDidChangeCursorPosition ({cursor}) =>
-      return unless cursor is activeEditor.getLastCursor()
-      @updatePosition()
-    @updatePosition()
+    selectionsMarkerLayer = activeEditor?.selectionsMarkerLayer
+    @cursorSubscription = selectionsMarkerLayer?.onDidUpdate(@scheduleUpdate.bind(this))
+    @scheduleUpdate()
 
   subscribeToConfig: ->
     @configSubscription?.dispose()
     @configSubscription = atom.config.observe 'status-bar.cursorPositionFormat', (value) =>
       @formatString = value ? '%L:%C'
-      @updatePosition()
+      @scheduleUpdate()
 
   handleClick: ->
     clickHandler = => atom.commands.dispatch(atom.views.getView(@getActiveTextEditor()), 'go-to-line:toggle')
@@ -53,7 +52,7 @@ class CursorPositionView
   getActiveTextEditor: ->
     atom.workspace.getActiveTextEditor()
 
-  updatePosition: ->
+  scheduleUpdate: ->
     return if @viewUpdatePending
 
     @viewUpdatePending = true

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -340,14 +340,17 @@ describe "Built-in Status Bar Tiles", ->
       it 'respects a format string', ->
         jasmine.attachToDOM(workspaceElement)
         editor.setSelectedBufferRange([[0, 0], [1, 30]])
+        atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe "2 foo 60 bar selected"
 
       it 'updates when the configuration changes', ->
         jasmine.attachToDOM(workspaceElement)
         editor.setSelectedBufferRange([[0, 0], [1, 30]])
+        atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe "2 foo 60 bar selected"
 
         atom.config.set('status-bar.selectionCountFormat', 'Selection: baz %C quux %L')
+        atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe "Selection: baz 60 quux 2"
 
       it 'does not include the next line if the last selected character is a LF', ->
@@ -356,6 +359,7 @@ describe "Built-in Status Bar Tiles", ->
         buffer.setText(buffer.getText().replace(lineEndingRegExp, '\n'))
         jasmine.attachToDOM(workspaceElement)
         editor.setSelectedBufferRange([[0, 0], [1, 0]])
+        atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe "1 foo 30 bar selected"
 
       it 'does not include the next line if the last selected character is CRLF', ->
@@ -364,6 +368,7 @@ describe "Built-in Status Bar Tiles", ->
         buffer.setText(buffer.getText().replace(lineEndingRegExp, '\r\n'))
         jasmine.attachToDOM(workspaceElement)
         editor.setSelectedBufferRange([[0, 0], [1, 0]])
+        atom.views.performDocumentUpdate()
         expect(selectionCount.textContent).toBe "1 foo 31 bar selected"
 
   describe "the git tile", ->


### PR DESCRIPTION
This pull request takes advantage of three techniques to speed up updates to the cursor position and the selection position views:

1. Instead of manipulating the DOM as soon as we get a "selection changed" event, we now request a new animation frame and wait until it is delivered before performing any update.
2. In `SelectionPositionView` we were previously removing and adding a new tooltip every time a selection changed. With this pull request we are using a new API that allows us to register the tooltip only once and directly manipulate its contents instead.
3. Instead of subscribing to the `editor.onDidChangeSelectionRange`, with this pull request we will listen for update events directly on the selections marker layer. These events are scheduled only once per transaction and, since they don't report any range, we can query the `DisplayMarker` and access its screen range only once right before changing the DOM.

/cc: @nathansobo 