### PR TITLE
Wait for save to complete in buffer modifier indicator test

### DIFF
--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -174,7 +174,12 @@ describe "Built-in Status Bar Tiles", ->
           editor.insertText("\n")
           advanceClock(buffer.stoppedChangingDelay)
           expect(fileInfo.classList.contains('buffer-modified')).toBe(true)
-          editor.getBuffer().save()
+
+        waitsForPromise ->
+          # TODO - remove this Promise.resolve once atom/atom#14435 lands.
+          Promise.resolve(editor.getBuffer().save())
+
+        runs ->
           expect(fileInfo.classList.contains('buffer-modified')).toBe(false)
 
       it "disables the buffer modified indicator if the content matches again", ->


### PR DESCRIPTION
The `TextBuffer.save` method is going to become async in atom/atom#14435; instead of doing a synchronous write, it will initiate an asynchronous write and return a promise when the write completes. This shouldn't affect the user-facing functionality of many packages; but several packages may have test failures.

This PR updates the one test in `status-bar` that broke due to this change, so that they work regardless of whether save is synchronous or asynchronous.