### PR TITLE
Restore ability to display info for pending pane items

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -13,8 +13,12 @@ class CursorPositionView
     @element.appendChild(@goToLineLink)
 
     @formatString = atom.config.get('status-bar.cursorPositionFormat') ? '%L:%C'
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) =>
-      @subscribeToActiveTextEditor()
+
+    # TODO[v1.19]: Remove conditional once atom.workspace.onDidChangeActiveTextEditor ships in Atom v1.19
+    if (atom.workspace.onDidChangeActiveTextEditor)
+      @activeItemSubscription = atom.workspace.onDidChangeActiveTextEditor (activeEditor) => @subscribeToActiveTextEditor()
+    else
+      @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) => @subscribeToActiveTextEditor()
 
     @subscribeToConfig()
     @subscribeToActiveTextEditor()

--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -15,7 +15,7 @@ class FileInfoView
 
     @element.getActiveItem = @getActiveItem.bind(this)
 
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
+    @activeItemSubscription = atom.workspace.getCenter().onDidChangeActivePaneItem =>
       @subscribeToActiveItem()
     @subscribeToActiveItem()
 
@@ -92,7 +92,7 @@ class FileInfoView
     @tooltip?.dispose()
 
   getActiveItem: ->
-    atom.workspace.getActivePaneItem()
+    atom.workspace.getCenter().getActivePaneItem()
 
   update: ->
     @updatePathText()

--- a/lib/git-view.coffee
+++ b/lib/git-view.coffee
@@ -11,7 +11,7 @@ class GitView
     @createCommitsArea()
     @createStatusArea()
 
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
+    @activeItemSubscription = atom.workspace.getCenter().onDidChangeActivePaneItem =>
       @subscribeToActiveItem()
     @projectPathSubscription = atom.project.onDidChangePaths =>
       @subscribeToRepositories()
@@ -97,7 +97,7 @@ class GitView
         return repo
 
   getActiveItem: ->
-    atom.workspace.getActivePaneItem()
+    atom.workspace.getCenter().getActivePaneItem()
 
   update: ->
     repo = @getRepositoryForActiveItem()

--- a/lib/selection-count-view.coffee
+++ b/lib/selection-count-view.coffee
@@ -10,8 +10,12 @@ class SelectionCountView
     @tooltipDisposable = atom.tooltips.add @element, item: @tooltipElement
 
     @formatString = atom.config.get('status-bar.selectionCountFormat') ? '(%L, %C)'
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
-      @subscribeToActiveTextEditor()
+
+    # TODO[v1.19]: Remove conditional once atom.workspace.onDidChangeActiveTextEditor ships in Atom v1.19
+    if (atom.workspace.onDidChangeActiveTextEditor)
+      @activeItemSubscription = atom.workspace.onDidChangeActiveTextEditor => @subscribeToActiveTextEditor()
+    else
+      @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem => @subscribeToActiveTextEditor()
 
     @subscribeToConfig()
     @subscribeToActiveTextEditor()

--- a/lib/status-bar-view.coffee
+++ b/lib/status-bar-view.coffee
@@ -31,7 +31,7 @@ class StatusBarView
 
     @bufferSubscriptions = []
 
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem =>
+    @activeItemSubscription = atom.workspace.getCenter().onDidChangeActivePaneItem =>
       @unsubscribeAllFromBuffer()
       @storeActiveBuffer()
       @subscribeAllToBuffer()
@@ -87,7 +87,7 @@ class StatusBarView
     @buffer
 
   getActiveItem: ->
-    atom.workspace.getActivePaneItem()
+    atom.workspace.getCenter().getActivePaneItem()
 
   storeActiveBuffer: ->
     @buffer = @getActiveItem()?.getBuffer?()


### PR DESCRIPTION
### Description of the Change

This PR is one part of resolving https://github.com/atom/status-bar/issues/194.

For status bar info that applies exclusively to text editors (e.g., cursor position and selection count), this PR updates this package to take advantage of the new `Workspace::observeActiveTextEditor(callback)` API being introduced in https://github.com/atom/atom/pull/14695.

For status bar info that can apply to non-text-editor pane items (e.g., displaying file name and git branch for image files, zip files, etc.), this PR updates this package to expect those pane items to exist in the workspace center.

### Alternate Designs

See https://github.com/atom/atom/pull/14695

### Benefits

The package will regain the ability to display info for pending pane items:

- file name
- cursor position
- selection position
- git branch

### Possible Drawbacks

See https://github.com/atom/atom/pull/14695

### Applicable Issues

- https://github.com/atom/atom/issues/14648
- https://github.com/atom/status-bar/issues/194

### Demo

#### Before

In the demo below, we start with an _active_ text editor (for the `.gitattributes` file) and then open another text editor (for the `.gitignore` file) in a pending pane. When opening the pending text editor, the status bar:

1. Does not show the file name for the pending text editor
1. Shows the previous editor's cursor position
1. Shows the previous editor's selection count
1. Does not show the git branch for the file

The user has to click on the pending text editor pane item in order to make the status bar show that info for the item.

![status-bar-before](https://cloud.githubusercontent.com/assets/2988/26785711/d92c8db8-49d1-11e7-8156-9dc269fa52bc.gif)

#### After

In the demo below, we follow the same steps as above. This time, when opening the pending text editor, the status bar shows:

1. The file name for the pending text editor
1. The cursor position for the pending text editor
1. Nothing for the selection count (since a pending pane item has no text selection)
1. The git branch for the file

![status-bar-after](https://cloud.githubusercontent.com/assets/2988/26785709/d45cbbfa-49d1-11e7-842d-7efb2c54827c.gif)
