### PR TITLE
Remove obsolete conditional re: `atom.workspace.onDidChangeActiveTextEditor `

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -14,11 +14,7 @@ class CursorPositionView
 
     @formatString = atom.config.get('status-bar.cursorPositionFormat') ? '%L:%C'
 
-    # TODO[v1.19]: Remove conditional once atom.workspace.onDidChangeActiveTextEditor ships in Atom v1.19
-    if (atom.workspace.onDidChangeActiveTextEditor)
-      @activeItemSubscription = atom.workspace.onDidChangeActiveTextEditor (activeEditor) => @subscribeToActiveTextEditor()
-    else
-      @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) => @subscribeToActiveTextEditor()
+    @activeItemSubscription = atom.workspace.onDidChangeActiveTextEditor (activeEditor) => @subscribeToActiveTextEditor()
 
     @subscribeToConfig()
     @subscribeToActiveTextEditor()

--- a/lib/selection-count-view.coffee
+++ b/lib/selection-count-view.coffee
@@ -11,11 +11,7 @@ class SelectionCountView
 
     @formatString = atom.config.get('status-bar.selectionCountFormat') ? '(%L, %C)'
 
-    # TODO[v1.19]: Remove conditional once atom.workspace.onDidChangeActiveTextEditor ships in Atom v1.19
-    if (atom.workspace.onDidChangeActiveTextEditor)
-      @activeItemSubscription = atom.workspace.onDidChangeActiveTextEditor => @subscribeToActiveTextEditor()
-    else
-      @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem => @subscribeToActiveTextEditor()
+    @activeItemSubscription = atom.workspace.onDidChangeActiveTextEditor => @subscribeToActiveTextEditor()
 
     @subscribeToConfig()
     @subscribeToActiveTextEditor()


### PR DESCRIPTION
This PR removes the conditional logic (originally introduced in #195) that tested for the existence of `atom.workspace.onDidChangeActiveTextEditor`. Now that Atom 1.19 has been released, we can safely expect `atom.workspace.onDidChangeActiveTextEditor` to be available: https://github.com/atom/atom/blob/v1.19.0/src/workspace.js#L665-L675
