### PR TITLE
Prevent badly behaved status bar items from causing the entire bar to scroll

### DIFF
--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -49,6 +49,10 @@ status-bar {
   .status-bar-left,
   .status-bar-right {
     overflow-x: auto;
+    // prevent badly behaved status bar items from causing vertical scrolling
+    // in the status bar. They can always implement overflow: auto to scroll
+    // within themselves.
+    overflow-y: hidden;
     &::-webkit-scrollbar {
       display: none;
     }


### PR DESCRIPTION
See GIF for this effect. This currently occurs with stock Atom (no packages
installed) from the auto-update squirrel icon and the Git status item.

![scroll-status](https://user-images.githubusercontent.com/755844/30983768-341f359a-a440-11e7-8914-fd1e21e9e1ed.gif)

If a status bar item really wants to overflow, it can always implement
itself as having overflow: auto within its own item.

cc @matthewwithanm 