### PR TITLE
When copying the relative path, paths should be relativized before UR…

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -53,16 +53,18 @@ class FileInfoView
   getActiveItemCopyText: (copyRelativePath) ->
     activeItem = @getActiveItem()
     path = activeItem?.getPath?()
+    return activeItem?.getTitle?() or '' if not path?
+
+    # Make sure we try to relativize before parsing URLs.
+    if copyRelativePath
+      relativized = atom.project.relativize(path)
+      if relativized isnt path
+        return relativized
+
     # An item path could be a url, we only want to copy the `path` part
     if path?.indexOf('://') > 0
       path = url.parse(path).path
-
-    return activeItem?.getTitle?() or '' if not path?
-
-    if copyRelativePath
-      atom.project.relativize(path)
-    else
-      path
+    path
 
   subscribeToActiveItem: ->
     @modifiedSubscription?.dispose()

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -64,6 +64,13 @@ describe "Built-in Status Bar Tiles", ->
         fileInfo.currentPath.click()
         expect(atom.clipboard.read()).toBe '/folder/remote_file.txt'
 
+      it "calls relativize with the remote URL on shift-click", ->
+        spy = spyOn(atom.project, 'relativize').andReturn 'remote_file.txt'
+        event = new MouseEvent('click', shiftKey: true)
+        fileInfo.currentPath.dispatchEvent(event)
+        expect(atom.clipboard.read()).toBe 'remote_file.txt'
+        expect(spy).toHaveBeenCalledWith 'remote://server:123/folder/remote_file.txt'
+
     describe "when buffer's path is clicked", ->
       it "copies the absolute path into the clipboard if available", ->
         waitsForPromise ->


### PR DESCRIPTION
For Nuclide's remote URLs, shift-click to relativize doesn't quite work correctly because the status bar calls `atom.project.relativize` after the URL has been stripped!

We used to be very lenient with our `relativize` functions, but now that we check that both URLs are remote this no longer works as intended.

The fix is simple: just call relativize before we do any fancy URL parsing.

Released under CC0.