### PR TITLE
Do not focus CursorPositionView after clicking on it

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -9,7 +9,6 @@ class CursorPositionView
     @element.classList.add('cursor-position', 'inline-block')
     @goToLineLink = document.createElement('a')
     @goToLineLink.classList.add('inline-block')
-    @goToLineLink.href = '#'
     @element.appendChild(@goToLineLink)
 
     @formatString = atom.config.get('status-bar.cursorPositionFormat') ? '%L:%C'
@@ -33,8 +32,7 @@ class CursorPositionView
 
   subscribeToActiveTextEditor: ->
     @cursorSubscription?.dispose()
-    activeEditor = @getActiveTextEditor()
-    selectionsMarkerLayer = activeEditor?.selectionsMarkerLayer
+    selectionsMarkerLayer = atom.workspace.getActiveTextEditor()?.selectionsMarkerLayer
     @cursorSubscription = selectionsMarkerLayer?.onDidUpdate(@scheduleUpdate.bind(this))
     @scheduleUpdate()
 
@@ -45,12 +43,9 @@ class CursorPositionView
       @scheduleUpdate()
 
   handleClick: ->
-    clickHandler = => atom.commands.dispatch(atom.views.getView(@getActiveTextEditor()), 'go-to-line:toggle')
+    clickHandler = -> atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'go-to-line:toggle')
     @element.addEventListener('click', clickHandler)
     @clickSubscription = new Disposable => @element.removeEventListener('click', clickHandler)
-
-  getActiveTextEditor: ->
-    atom.workspace.getActiveTextEditor()
 
   scheduleUpdate: ->
     return if @viewUpdatePending
@@ -58,7 +53,7 @@ class CursorPositionView
     @viewUpdatePending = true
     @updateSubscription = atom.views.updateDocument =>
       @viewUpdatePending = false
-      if position = @getActiveTextEditor()?.getCursorBufferPosition()
+      if position = atom.workspace.getActiveTextEditor()?.getCursorBufferPosition()
         @row = position.row + 1
         @column = position.column + 1
         @goToLineLink.textContent = @formatString.replace('%L', @row).replace('%C', @column)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Keep the focus on whatever element was focused before the cursor position tile is clicked.

### Alternate Designs

None.

### Benefits

This tile can no longer be focused and will instead transfer focus back to the original element.  Which means that you can open the Go to Line modal panel, cancel it, and continue typing like nothing happened.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #82