### PR TITLE
Mark LaunchModeView as read-only

### DIFF
--- a/lib/launch-mode-view.coffee
+++ b/lib/launch-mode-view.coffee
@@ -2,7 +2,7 @@ module.exports =
 class LaunchModeView
   constructor: ({safeMode, devMode}={}) ->
     @element = document.createElement('status-bar-launch-mode')
-    @element.classList.add('inline-block', 'icon', 'icon-color-mode')
+    @element.classList.add('inline-block', 'icon', 'icon-color-mode', 'is-read-only')
     if devMode
       @element.classList.add('text-error')
       @tooltipDisposable = atom.tooltips.add(@element, title: 'This window is in dev mode')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Because it is.  Should remove the need to special-case `status-bar-launch-mode` in the One themes.

### Alternate Designs

None.

### Benefits

Removal of special-casing in the One themes.

### Possible Drawbacks

None.

### Applicable Issues

None.

/cc @simurai is this worth doing?