### PR TITLE
Use tab length setting to calculate column number

### DIFF
--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -67,5 +67,5 @@ class CursorPositionView
   calculateColumnNumber: (editor, bufferPosition) ->
     text = editor.lineTextForBufferRow(bufferPosition.row)
     prefixChars = text.slice(0, bufferPosition.column).split('')
-    numTabs = prefixChars.filter((c) -> c == '\t').length
+    numTabs = prefixChars.filter((c) -> c is '\t').length
     return bufferPosition.column + numTabs * (editor.getTabLength() - 1)

--- a/lib/cursor-position-view.coffee
+++ b/lib/cursor-position-view.coffee
@@ -53,11 +53,19 @@ class CursorPositionView
     @viewUpdatePending = true
     @updateSubscription = atom.views.updateDocument =>
       @viewUpdatePending = false
-      if position = atom.workspace.getActiveTextEditor()?.getCursorBufferPosition()
+      activeEditor = atom.workspace.getActiveTextEditor()
+      if position = activeEditor?.getCursorBufferPosition()
+        columnNumber = @calculateColumnNumber(activeEditor, position)
         @row = position.row + 1
-        @column = position.column + 1
+        @column = columnNumber + 1
         @goToLineLink.textContent = @formatString.replace('%L', @row).replace('%C', @column)
         @element.classList.remove('hide')
       else
         @goToLineLink.textContent = ''
         @element.classList.add('hide')
+
+  calculateColumnNumber: (editor, bufferPosition) ->
+    text = editor.lineTextForBufferRow(bufferPosition.row)
+    prefixChars = text.slice(0, bufferPosition.column).split('')
+    numTabs = prefixChars.filter((c) -> c == '\t').length
+    return bufferPosition.column + numTabs * (editor.getTabLength() - 1)

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -255,6 +255,13 @@ describe "Built-in Status Bar Tiles", ->
           atom.views.performDocumentUpdate()
           expect(cursorPosition).toBeHidden()
 
+      it "counts hard tabs using the editor's tab-length setting", ->
+        jasmine.attachToDOM(workspaceElement)
+        editor.setCursorBufferPosition([16, 1])
+        atom.views.performDocumentUpdate()
+        tabLength = editor.getTabLength()
+        expect(cursorPosition.textContent).toBe "17:#{tabLength + 1}"
+
     describe "when the associated editor's selection changes", ->
       it "updates the selection count in the status bar", ->
         jasmine.attachToDOM(workspaceElement)

--- a/spec/fixtures/sample.js
+++ b/spec/fixtures/sample.js
@@ -11,3 +11,8 @@ var quicksort = function () {
 
   return sort(Array.apply(this, arguments));
 };
+
+// This function uses hard-tab indentation to test the cursor position view
+function testTabs() {
+	return true;
+}


### PR DESCRIPTION
### Description of the Change

Before now, the column number was a count of the number of characters to
the left of the cursor in the current row. This meant that hard tabs
were each counted as one character, even though they were displayed
according to the user’s tab-length setting, and so could take up any number of columns on-screen.

This fix uses the user’s tab-length setting as the width of each tab
character when calculating the column number.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- I considered using the screen position instead of the buffer position, as this would account for the tabs automatically. However, for soft-wrapped lines, the wrapped parts are counted as separate lines, which I don’t think is a desirable behaviour.

### Benefits

<!-- What benefits will be realized by the code change? -->

- Users using hard tabs will be able to accurately read the screen length of their lines of code (according to their tab setting).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Definite drawback: Inconsistency with the `Go To Line` dialog.

- When you click on the row:column indicator, the `Go To Line: Toggle` command is run. This opens a dialog box where you can enter a value in a format described as “row:column”.
- As this is part of atom core, this interprets tabs as 1 column.
- So, entering the value displayed by the cursor-position tile will cause the cursor to change position.

I’m not sure what the solution to this drawback is. One possibility might be to change the wording in that dialog to “row:character” or something similar.

### Applicable Issues

<!-- Enter any applicable Issues here -->

https://github.com/atom/status-bar/issues/170
