### PR TITLE
Clicking anywhere in the file info tile copies the buffer path

### DIFF
--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -46,7 +46,7 @@ class FileInfoView
     text = @getActiveItemCopyText(copyRelativePath)
     @copiedTooltip = atom.tooltips.add @element,
       title: "Copied: #{text}"
-      trigger: 'click'
+      trigger: 'manual'
       delay:
         show: 0
 

--- a/lib/file-info-view.coffee
+++ b/lib/file-info-view.coffee
@@ -29,8 +29,8 @@ class FileInfoView
         @clearCopiedTooltip()
       , 2000
 
-    @currentPath.addEventListener('click', clickHandler)
-    @clickSubscription = new Disposable => @currentPath.removeEventListener('click', clickHandler)
+    @element.addEventListener('click', clickHandler)
+    @clickSubscription = new Disposable => @element.removeEventListener('click', clickHandler)
 
   registerTooltip: ->
     @tooltip = atom.tooltips.add(@element, title: ->

--- a/spec/built-in-tiles-spec.coffee
+++ b/spec/built-in-tiles-spec.coffee
@@ -67,9 +67,18 @@ describe "Built-in Status Bar Tiles", ->
       it "calls relativize with the remote URL on shift-click", ->
         spy = spyOn(atom.project, 'relativize').andReturn 'remote_file.txt'
         event = new MouseEvent('click', shiftKey: true)
-        fileInfo.currentPath.dispatchEvent(event)
+        fileInfo.dispatchEvent(event)
         expect(atom.clipboard.read()).toBe 'remote_file.txt'
         expect(spy).toHaveBeenCalledWith 'remote://server:123/folder/remote_file.txt'
+
+    describe "when file info tile is clicked", ->
+      it "copies the absolute path into the clipboard if available", ->
+        waitsForPromise ->
+          atom.workspace.open('sample.txt')
+
+        runs ->
+          fileInfo.click()
+          expect(atom.clipboard.read()).toBe fileInfo.getActiveItem().getPath()
 
     describe "when buffer's path is clicked", ->
       it "copies the absolute path into the clipboard if available", ->
@@ -80,14 +89,14 @@ describe "Built-in Status Bar Tiles", ->
           fileInfo.currentPath.click()
           expect(atom.clipboard.read()).toBe fileInfo.getActiveItem().getPath()
 
-    describe "when buffer's path is shift-clicked", ->
+    describe "when the file info tile is shift-clicked", ->
       it "copies the relative path into the clipboard if available", ->
         waitsForPromise ->
           atom.workspace.open('sample.txt')
 
         runs ->
           event = new MouseEvent('click', shiftKey: true)
-          fileInfo.currentPath.dispatchEvent(event)
+          fileInfo.dispatchEvent(event)
           expect(atom.clipboard.read()).toBe 'sample.txt'
 
     describe "when path of an unsaved buffer is clicked", ->


### PR DESCRIPTION
### Description of the Change

Hovering over the edge areas of the file info tile (`<status-bar-file>`), but not its inner buffer path text (`<a>`), displays the `Click to copy...` tooltip. However, clicking within this area not copy the path. Depending on editor theme, hover styling may additionally suggest that behavior will occur on a click. This can be confusing to the user, and in personal experience, I sometimes click this area quickly only to paste elsewhere and discover I didn't actually get the path onto the clipboard.

This PR moves the click handling that adds the path to the clipboard and displays the `Copied: ...` tooltip to the path's parent element, so clicking anywhere on the tile has the desired effect.

### Alternate Designs

One alternative I considered was moving where we add the `Click to copy...` tooltip so it only displays when hovering directly over the path. I felt this ultimately made the tile less useable, and other hover styling would still leave behind a misleading impression.

### Benefits

Easier to copy paths from the file info tile; clicking in the edge areas does not 'fake out' the user.

### Possible Drawbacks

- Expanding the clickable area increases the chance someone could accidentally copy the path and lose something on their clipboard.
- Themes where the path's `<a>` element has its own hover styling may mislead the user into thinking that clicking the path itself has different functionality from clicking the outer edges of the tile.

### Applicable Issues

I did not find any issues related to this change.
